### PR TITLE
Ensure process graphs with only load_collection and save_result work.

### DIFF
--- a/src/pg_to_evalscript/evalscript.py
+++ b/src/pg_to_evalscript/evalscript.py
@@ -106,7 +106,7 @@ function updateOutput(outputs, collection) {{
 
         if len(self.nodes) == 0:
             return initial_output_dimensions
-        
+
         dimensions_of_inputs_per_node[self.nodes[0].node_id].append(initial_output_dimensions)
 
         for node in self.nodes:

--- a/src/pg_to_evalscript/evalscript.py
+++ b/src/pg_to_evalscript/evalscript.py
@@ -61,7 +61,7 @@ function setup() {{
 function evaluatePixel(samples) {{
     {self.write_datacube_creation()}
     {(newline + tab).join([node.write_call() for node in self.nodes])}
-    return {self.nodes[-1].node_varname_prefix + self.nodes[-1].node_id}{".encodeData()" if self.encode_result else '.flattenToArray()'}
+    return {self.write_output_variable()}{".encodeData()" if self.encode_result else '.flattenToArray()'}
 }}
 """
 
@@ -92,12 +92,21 @@ function updateOutput(outputs, collection) {{
     }});
 }}"""
 
+    def write_output_variable(self):
+        if len(self.nodes) == 0:
+            return self.initial_data_name
+        return self.nodes[-1].node_varname_prefix + self.nodes[-1].node_id
+
     def determine_output_dimensions(self):
         dimensions_of_inputs_per_node = defaultdict(list)
         initial_output_dimensions = [
             {"name": self.bands_dimension_name, "size": len(self.input_bands)},
             {"name": self.temporal_dimension_name, "size": None, "original_temporal": True},
         ]
+
+        if len(self.nodes) == 0:
+            return initial_output_dimensions
+        
         dimensions_of_inputs_per_node[self.nodes[0].node_id].append(initial_output_dimensions)
 
         for node in self.nodes:

--- a/tests/integration_tests/test_integration.py
+++ b/tests/integration_tests/test_integration.py
@@ -8,7 +8,7 @@ from tests.utils import get_process_graph_json, run_evalscript
 
 @pytest.mark.parametrize(
     "pg_name,example_input,expected_output",
-    [("test_graph_1", [{"B01": 3, "B02": 3}, {"B01": 5, "B02": 1}], [4, 2])],
+    [("test_graph_1", [{"B01": 3, "B02": 3}, {"B01": 5, "B02": 1}], [4, 2]), ("test_short_graph", [{"B01": 3, "B02": 2}, {"B01": 5, "B02": 1}], [3,2,5,1])],
 )
 def test_convertable_process_graphs(pg_name, example_input, expected_output):
     process_graph = get_process_graph_json(pg_name)

--- a/tests/integration_tests/test_integration.py
+++ b/tests/integration_tests/test_integration.py
@@ -8,7 +8,10 @@ from tests.utils import get_process_graph_json, run_evalscript
 
 @pytest.mark.parametrize(
     "pg_name,example_input,expected_output",
-    [("test_graph_1", [{"B01": 3, "B02": 3}, {"B01": 5, "B02": 1}], [4, 2]), ("test_short_graph", [{"B01": 3, "B02": 2}, {"B01": 5, "B02": 1}], [3,2,5,1])],
+    [
+        ("test_graph_1", [{"B01": 3, "B02": 3}, {"B01": 5, "B02": 1}], [4, 2]),
+        ("test_short_graph", [{"B01": 3, "B02": 2}, {"B01": 5, "B02": 1}], [3, 2, 5, 1]),
+    ],
 )
 def test_convertable_process_graphs(pg_name, example_input, expected_output):
     process_graph = get_process_graph_json(pg_name)

--- a/tests/process_graphs/test_short_graph.json
+++ b/tests/process_graphs/test_short_graph.json
@@ -1,0 +1,29 @@
+{
+   "loadco1":{
+      "process_id":"load_collection",
+      "arguments":{
+         "id":"S2L1C",
+         "spatial_extent":{
+            "west":16.1,
+            "east":16.6,
+            "north":48.6,
+            "south":47.2
+         },
+         "temporal_extent":[
+            "2017-01-01",
+            "2017-02-01"
+         ],
+         "bands": ["B01", "B02"]
+      }
+   },
+   "saveres1":{
+      "process_id":"save_result",
+      "arguments":{
+         "data":{
+            "from_node":"loadco1"
+         },
+         "format":"gtiff"
+      },
+      "result":true
+   }
+}


### PR DESCRIPTION
Closes https://git.sinergise.com/team-6/openeo-platform/-/issues/49

So the issue didn't really make *a lot* of sense. Namely, having just `load_collection` is a completely useless graph. With these changes it should no longer results in an error though. However, I decided not to make a test case for it. 

Instead I made a test case for a graph with just `load_collection` and `save_result`, because that makes sense.