### PR TITLE
Add Github action to publish pg_to_evalscript on Pypi

### DIFF
--- a/.github/workflows/publish_to_pypi.yml
+++ b/.github/workflows/publish_to_pypi.yml
@@ -7,13 +7,13 @@ on:
 jobs:
   build-and-publish:
     name: Build and publish to PyPI
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
 
     - name: Set up Python 3.8
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v2
       with:
         python-version: 3.8
 

--- a/.github/workflows/publish_to_pypi.yml
+++ b/.github/workflows/publish_to_pypi.yml
@@ -1,0 +1,39 @@
+name: Publish to PyPI
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  build-and-publish:
+    name: Build and publish to PyPI
+    runs-on: ubuntu-18.04
+
+    steps:
+    - uses: actions/checkout@v1
+
+    - name: Set up Python 3.8
+      uses: actions/setup-python@v1
+      with:
+        python-version: 3.8
+
+    - name: Install pypa/build
+      run: >-
+        python -m
+        pip install
+        build
+        --user
+
+    - name: Build a binary wheel and a source tarball
+      env:
+          GITHUB_REF_TAG: ${{ github.ref }}
+      run: |
+        echo "Extracting version from GITHUB_REF_TAG: $GITHUB_REF_TAG"
+        export PG_TO_EVALSCRIPT_VERSION=$(echo "$GITHUB_REF_TAG" | sed -e "s#^refs/tags/##")
+        python -m build --sdist --wheel --outdir dist/ .
+
+    - name: Publish to PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        user: __token__
+        password: ${{ secrets.PYPI_API_TOKEN }}

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,9 @@
+import os
 from setuptools import setup, find_packages
 
 setup(
     name="pg_to_evalscript",
-    version="0.0.1",
+    version=os.environ.get("PG_TO_EVALSCRIPT_VERSION", "0.0.0"),
     packages=["pg_to_evalscript"],
     package_data={"pg_to_evalscript": ["javascript_datacube/*.js", "javascript_processes/*.js"]},
 )


### PR DESCRIPTION
Closes https://git.sinergise.com/team-6/openeo-platform/-/issues/50

Made release `0.1.0` https://pypi.org/project/pg-to-evalscript/0.1.0/#history

Was also tested on another branch [feature/publish-test-pypi](https://github.com/openEOPlatform/openeo-pg-evalscript-converter/tree/feature/publish-test-pypi) (`0.0.1rc5`): https://test.pypi.org/project/pg-to-evalscript/#history

Based on:

- https://packaging.python.org/en/latest/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/
- https://github.com/sentinel-hub/sentinelhub-js/blob/5c8aeafd3af8e88f8bbe830b996b6ff9d3981442/.github/workflows/on_release.yaml
