### PR TITLE
add / SIN and COS processes

### DIFF
--- a/src/pg_to_evalscript/javascript_processes/cos.js
+++ b/src/pg_to_evalscript/javascript_processes/cos.js
@@ -1,0 +1,20 @@
+function cos(arguments) {
+  const { x } = arguments;
+
+  if (x === undefined) {
+    throw new Error("Mandatory argument `x` is not defined.");
+  }
+
+  if (x === null) {
+    return null;
+  }
+
+  if (typeof x !== "number") {
+    throw new Error("Argument `x` is not a number.");
+  }
+
+  // floating point handling in javascript is ... special
+  // cos((n * PI) / 2) is not exactly 0 (for n = any int value)
+  // TODO
+  return Math.cos(x);
+}

--- a/src/pg_to_evalscript/javascript_processes/sin.js
+++ b/src/pg_to_evalscript/javascript_processes/sin.js
@@ -1,0 +1,20 @@
+function sin(arguments) {
+  const { x } = arguments;
+  
+  if (x === undefined) {
+    throw new Error("Mandatory argument `x` is not defined.");
+  }
+
+  if(x === null){
+    return null;
+  }
+
+  if (typeof x !== "number") {
+    throw new Error("Argument `x` is not a number.");
+  }
+
+  // floating point handling in javascript is ... special
+  // sin(n * PI) is not exactly 0 in Javascript (for n = any int value)
+  // TODO
+  return Math.sin(x);
+}

--- a/src/pg_to_evalscript/javascript_processes/sin.js
+++ b/src/pg_to_evalscript/javascript_processes/sin.js
@@ -14,7 +14,7 @@ function sin(arguments) {
   }
 
   // floating point handling in javascript is ... special
-  // sin(n * PI) is not exactly 0 in Javascript (for n = any int value)
+  // sin(n * PI) is not exactly 0 (for n = any int value)
   // TODO
   return Math.sin(x);
 }

--- a/tests/unit_tests/test_cos.py
+++ b/tests/unit_tests/test_cos.py
@@ -1,0 +1,49 @@
+import json
+import math
+
+import pytest
+
+from tests.utils import load_process_code, run_process
+
+
+@pytest.fixture
+def cos_process_code():
+    return load_process_code("cos")
+
+
+@pytest.mark.parametrize(
+    "example_input,expected_output",
+    [
+        ({"x": 0}, 1),
+        ({"x": math.pi / 2}, 0),
+        ({"x": math.pi}, -1),
+        ({"x": 3 * math.pi / 2}, 0),
+        ({"x": 2 * math.pi}, 1),
+        ({"x": None}, None),
+    ],
+)
+def test_cos(cos_process_code, example_input, expected_output):
+    output = run_process(cos_process_code, "cos", example_input)
+    output = json.loads(output)
+    assert output == expected_output
+
+
+@pytest.mark.parametrize(
+    "example_input,raises_exception,error_message",
+    [
+        ({"x": 0}, False, None),
+        ({}, True, "Mandatory argument `x` is not defined."),
+        ({"y": 0.5}, True, "Mandatory argument `x` is not defined."),
+        ({"x": "0.5"}, True, "Argument `x` is not a number."),
+    ],
+)
+def test_cos_exceptions(
+    cos_process_code, example_input, raises_exception, error_message
+):
+    if raises_exception:
+        with pytest.raises(Exception) as exc:
+            run_process(cos_process_code, "cos", example_input)
+        assert error_message in str(exc.value)
+
+    else:
+        run_process(cos_process_code, "cos", example_input)

--- a/tests/unit_tests/test_sin.py
+++ b/tests/unit_tests/test_sin.py
@@ -1,0 +1,49 @@
+import json
+import math
+
+import pytest
+
+from tests.utils import load_process_code, run_process
+
+
+@pytest.fixture
+def sin_process_code():
+    return load_process_code("sin")
+
+
+@pytest.mark.parametrize(
+    "example_input,expected_output",
+    [
+        ({"x": 0}, 0),
+        ({"x": math.pi / 2}, 1),
+        ({"x": math.pi}, 0),
+        ({"x": 3 * math.pi / 2}, -1),
+        ({"x": 2 * math.pi}, 0),
+        ({"x": None}, None),
+    ],
+)
+def test_sin(sin_process_code, example_input, expected_output):
+    output = run_process(sin_process_code, "sin", example_input)
+    output = json.loads(output)
+    assert output == expected_output
+
+
+@pytest.mark.parametrize(
+    "example_input,raises_exception,error_message",
+    [
+        ({"x": 0}, False, None),
+        ({}, True, "Mandatory argument `x` is not defined."),
+        ({"y": 0.5}, True, "Mandatory argument `x` is not defined."),
+        ({"x": "0.5"}, True, "Argument `x` is not a number."),
+    ],
+)
+def test_sin_exceptions(
+    sin_process_code, example_input, raises_exception, error_message
+):
+    if raises_exception:
+        with pytest.raises(Exception) as exc:
+            run_process(sin_process_code, "sin", example_input)
+        assert error_message in str(exc.value)
+
+    else:
+        run_process(sin_process_code, "sin", example_input)


### PR DESCRIPTION
https://git.sinergise.com/team-6/openeo-platform/-/issues/84

floating point handling in javascript is ... special, so all trigonometric functions (sin, cos, tan, ...) return slightly wrong values for some of the inputs.

e.g.


math: 
`sin(PI) = 0`

js:
```javascript
> console.log(Math.sin(Math.PI));
1.2246467991473532e-16
```

Problem is most apparent for inputs `n * PI` for `n = any int value`

---

math:
`cos(PI/2) = 0`

js:
```javascript
> console.log(Math.cos(Math.PI/2));
6.123233995736766e-17
```

Problem is most apparent for inputs `(n * PI)/2` for `n = any int value`