### PR TITLE
add / PI process

### DIFF
--- a/src/pg_to_evalscript/javascript_processes/pi.js
+++ b/src/pg_to_evalscript/javascript_processes/pi.js
@@ -1,0 +1,3 @@
+function pi() {
+  return Math.PI;
+}

--- a/tests/unit_tests/test_pi.py
+++ b/tests/unit_tests/test_pi.py
@@ -1,0 +1,23 @@
+import json
+import math
+
+import pytest
+
+from tests.utils import load_process_code, run_process
+
+
+@pytest.fixture
+def pi_process_code():
+    return load_process_code("pi")
+
+
+@pytest.mark.parametrize(
+    "example_input,expected_output",
+    [
+        ({}, math.pi),
+    ],
+)
+def test_pi(pi_process_code, example_input, expected_output):
+    output = run_process(pi_process_code, "pi", example_input)
+    output = json.loads(output)
+    assert output == expected_output


### PR DESCRIPTION
https://git.sinergise.com/team-6/openeo-platform/-/issues/85

both javascript and python have the same value for PI (`3.141592653589793`).
The value from the [docs](https://docs.openeo.cloud/processes/#pi) with less decimals could also be used (`3.14159`)