### PR TITLE
add array_interpolate_linear process

### DIFF
--- a/src/pg_to_evalscript/javascript_processes/array_interpolate_linear.js
+++ b/src/pg_to_evalscript/javascript_processes/array_interpolate_linear.js
@@ -7,6 +7,10 @@ function array_interpolate_linear(arguments) {
     );
   }
 
+  if (!Array.isArray(data)) {
+    throw new Error("Argument `data` is not an array.");
+  }
+
   const linear_interpolation = (v0, v1, t) => (1 - t) * v0 + t * v1;
   let newData = [...data];
   let start = newData[0];

--- a/src/pg_to_evalscript/javascript_processes/array_interpolate_linear.js
+++ b/src/pg_to_evalscript/javascript_processes/array_interpolate_linear.js
@@ -3,7 +3,7 @@ function array_interpolate_linear(arguments) {
 
   if (data === null || data === undefined) {
     throw new Error(
-      "Mandatory argument `array` is either null or not defined."
+      "Mandatory argument `data` is either null or not defined."
     );
   }
 

--- a/src/pg_to_evalscript/javascript_processes/array_interpolate_linear.js
+++ b/src/pg_to_evalscript/javascript_processes/array_interpolate_linear.js
@@ -1,0 +1,45 @@
+function array_interpolate_linear(arguments) {
+  const { data } = arguments;
+
+  if (data === null || data === undefined) {
+    throw new Error(
+      "Mandatory argument `array` is either null or not defined."
+    );
+  }
+
+  const linear_interpolation = (v0, v1, t) => (1 - t) * v0 + t * v1;
+  let newData = [...data];
+  let start = newData[0];
+  let end = newData[0];
+  let nullIndices = [];
+
+  for (let i = 0; i < newData.length; i++) {
+    if (newData[i] === null) {
+      if (i === 0 || i === newData.length - 1) {
+        continue;
+      }
+
+      nullIndices.push(i);
+      continue;
+    }
+
+    if (typeof newData[i] !== "number") {
+      throw new Error("Element in `data` is not of correct type.");
+    }
+
+    end = newData[i];
+
+    if (start !== null && end !== null) {
+      for (let j = 0; j < nullIndices.length; j++) {
+        const t = (j + 1) / (nullIndices.length + 1);
+
+        newData[nullIndices[j]] = linear_interpolation(start, end, t);
+      }
+    }
+
+    start = newData[i];
+    nullIndices = [];
+  }
+
+  return newData;
+}

--- a/tests/unit_tests/test_array_interpolate_linear.py
+++ b/tests/unit_tests/test_array_interpolate_linear.py
@@ -43,6 +43,7 @@ def test_array_interpolate_linear(
             "Mandatory argument `data` is either null or not defined.",
         ),
         ({}, True, "Mandatory argument `data` is either null or not defined."),
+        ({"data": "[1]"}, True, "Argument `data` is not an array."),
         ({"data": [1, 2, "3"]}, True, "Element in `data` is not of correct type."),
     ],
 )

--- a/tests/unit_tests/test_array_interpolate_linear.py
+++ b/tests/unit_tests/test_array_interpolate_linear.py
@@ -1,0 +1,68 @@
+import json
+
+import pytest
+
+from tests.utils import load_process_code, run_process
+
+
+@pytest.fixture
+def array_interpolate_linear_process_code():
+    return load_process_code("array_interpolate_linear")
+
+
+@pytest.mark.parametrize(
+    "example_input,expected_output",
+    [
+        ({"data": [1, 2, 3]}, [1, 2, 3]),
+        ({"data": [1, None, None, 4]}, [1, 2, 3, 4]),
+        ({"data": [None, 1, None, 6, None, -8, None]}, [None, 1, 3.5, 6, -1, -8, None]),
+        ({"data": [None, None, None]}, [None, None, None]),
+        ({"data": [1, None, None]}, [1, None, None]),
+        ({"data": [None, None, 1]}, [None, None, 1]),
+        ({"data": [None, 1, None]}, [None, 1, None]),
+    ],
+)
+def test_array_interpolate_linear(
+    array_interpolate_linear_process_code, example_input, expected_output
+):
+    output = run_process(
+        array_interpolate_linear_process_code, "array_interpolate_linear", example_input
+    )
+    output = json.loads(output)
+    assert output == expected_output
+
+
+@pytest.mark.parametrize(
+    "example_input,raises_exception,error_message",
+    [
+        ({"data": [1, None, 3]}, False, None),
+        (
+            {"data": None},
+            True,
+            "Mandatory argument `array` is either null or not defined.",
+        ),
+        ({}, True, "Mandatory argument `array` is either null or not defined."),
+        ({"data": [1, 2, "3"]}, True, "Element in `data` is not of correct type."),
+    ],
+)
+def test_array_interpolate_linear_exceptions(
+    array_interpolate_linear_process_code,
+    example_input,
+    raises_exception,
+    error_message,
+):
+    if raises_exception:
+        with pytest.raises(Exception) as exc:
+            run_process(
+                array_interpolate_linear_process_code,
+                "array_interpolate_linear",
+                example_input,
+            )
+        assert error_message in str(exc.value)
+
+    else:
+        run_process(
+            array_interpolate_linear_process_code,
+            "array_interpolate_linear",
+            example_input,
+        )

--- a/tests/unit_tests/test_array_interpolate_linear.py
+++ b/tests/unit_tests/test_array_interpolate_linear.py
@@ -40,9 +40,9 @@ def test_array_interpolate_linear(
         (
             {"data": None},
             True,
-            "Mandatory argument `array` is either null or not defined.",
+            "Mandatory argument `data` is either null or not defined.",
         ),
-        ({}, True, "Mandatory argument `array` is either null or not defined."),
+        ({}, True, "Mandatory argument `data` is either null or not defined."),
         ({"data": [1, 2, "3"]}, True, "Element in `data` is not of correct type."),
     ],
 )

--- a/tests/unit_tests/test_array_interpolate_linear.py
+++ b/tests/unit_tests/test_array_interpolate_linear.py
@@ -20,6 +20,7 @@ def array_interpolate_linear_process_code():
         ({"data": [1, None, None]}, [1, None, None]),
         ({"data": [None, None, 1]}, [None, None, 1]),
         ({"data": [None, 1, None]}, [None, 1, None]),
+        ({"data": []}, []),
     ],
 )
 def test_array_interpolate_linear(


### PR DESCRIPTION
https://git.sinergise.com/team-6/openeo-platform/-/issues/97

docs: https://docs.openeo.cloud/processes/?#array_interpolate_linear


A return type in the docs is `number|null` but there is nothing about propagating `null` if the array is `null` or empty (like for some of the other processes). So, I'm not sure.