### PR TITLE
Cleanup datacube and add tests

### DIFF
--- a/src/pg_to_evalscript/javascript_datacube/DataCube.js
+++ b/src/pg_to_evalscript/javascript_datacube/DataCube.js
@@ -35,7 +35,7 @@ class DataCube {
     makeArrayFromSamples(samples) {
         if (Array.isArray(samples)) {
             if (samples.length === 0) {
-                return ndarray([], [0,0])
+                return ndarray([], [0, 0])
             }
             this._setDimensionLabelsIfEmpty(this.bands_dimension_name, Object.keys(samples[0]))
             let newData = []
@@ -158,24 +158,23 @@ class DataCube {
         this.data = ndarray(this.data.data, this.data.shape)
     }
 
-    _filter(dim, coordArr) {
-        const shape = this.data.shape
+    // axis: integer, index of the dimension to filter
+    // coordArr: array of indices of the dimension to keep
+    _filter(axis, coordArr) {
         const length = this.data.data.length
-        const stepSlice = shape.slice(dim)
-        shape[dim] = coordArr.length
+        const stride = this.data.stride[axis]
+        const axisSize = this.data.shape[axis]
         const newData = []
-        let step = 1
-
-        for (let s of stepSlice) {
-            step *= s
-        }
 
         for (let i = 0; i < length; i++) {
-            if (coordArr.includes(i % step)) {
+            if (coordArr.includes(Math.floor(i / stride) % axisSize)) {
                 newData.push(this.data.data[i])
             }
         }
-        this.data = ndarray(newData, shape)
+
+        const newShape = this.data.shape
+        newShape[axis] = coordArr.length
+        this.data = ndarray(newData, newShape)
     }
 
     // process: function, accepts `data` (labeled array) and `context` (any)
@@ -192,7 +191,7 @@ class DataCube {
     // Generator that visits all coordinates of array with `shape`, keeping nullAxes `null`
     // shape: sizes of dimensions
     // nullAxes: array with axes that should be kept null
-    * _iterateCoords(shape, nullAxes=[]) {
+    * _iterateCoords(shape, nullAxes = []) {
         const cumulatives = fill(shape.slice(), 0);
         const coords = shape.slice();
         for (let axis of nullAxes) {

--- a/src/pg_to_evalscript/javascript_datacube/DataCube.js
+++ b/src/pg_to_evalscript/javascript_datacube/DataCube.js
@@ -108,6 +108,10 @@ class DataCube {
     }
 
     flattenToArray() {
+        if ((!this.data.shape || this.data.shape.length === 0) && this.data.data.length === 1) {
+            // If there is no data.shape or it's [], we have a scalar.
+            return this.data.data[0]
+        }
         return flattenToNativeArray(this.data)
     }
 

--- a/src/pg_to_evalscript/javascript_datacube/DataCube.js
+++ b/src/pg_to_evalscript/javascript_datacube/DataCube.js
@@ -42,7 +42,8 @@ class DataCube {
             if (this.getDimensionByName(this.bands_dimension_name).labels.length === 0) {
                 this.getDimensionByName(this.bands_dimension_name).labels = Object.keys(samples)
             }
-            return ndarray(new Float64Array(Object.values(samples)), [1, samples.length])
+            const newData = Object.values(samples)
+            return ndarray(newData, [1, newData.length])
         }
     }
 

--- a/src/pg_to_evalscript/javascript_datacube/DataCube.js
+++ b/src/pg_to_evalscript/javascript_datacube/DataCube.js
@@ -37,20 +37,22 @@ class DataCube {
             if (samples.length === 0) {
                 return ndarray([], [0,0])
             }
-            if (this.getDimensionByName(this.bands_dimension_name).labels.length === 0) {
-                this.getDimensionByName(this.bands_dimension_name).labels = Object.keys(samples[0]) // Sets bands names as bands dimension labels
-            }
+            this._setDimensionLabelsIfEmpty(this.bands_dimension_name, Object.keys(samples[0]))
             let newData = []
             for (let entry of samples) {
                 newData = newData.concat(extractValues(entry))
             }
             return ndarray(newData, [samples.length, extractValues(samples[0]).length])
         } else {
-            if (this.getDimensionByName(this.bands_dimension_name).labels.length === 0) {
-                this.getDimensionByName(this.bands_dimension_name).labels = Object.keys(samples)
-            }
+            this._setDimensionLabelsIfEmpty(this.bands_dimension_name, Object.keys(samples))
             const newData = Object.values(samples)
             return ndarray(newData, [1, newData.length])
+        }
+    }
+
+    _setDimensionLabelsIfEmpty(dimension, labels) {
+        if (this.getDimensionByName(dimension).labels.length === 0) {
+            this.getDimensionByName(dimension).labels = labels
         }
     }
 
@@ -109,7 +111,7 @@ class DataCube {
 
     flattenToArray() {
         if ((!this.data.shape || this.data.shape.length === 0) && this.data.data.length === 1) {
-            // If there is no data.shape or it's [], we have a scalar.
+            // We have a scalar.
             return this.data.data[0]
         }
         return flattenToNativeArray(this.data)

--- a/src/pg_to_evalscript/javascript_datacube/DataCube.js
+++ b/src/pg_to_evalscript/javascript_datacube/DataCube.js
@@ -35,7 +35,7 @@ class DataCube {
         // Either object or array of objects (non-temporal and temporal scripts respectively)
         if (Array.isArray(samples)) {
             if (samples.length === 0) {
-                return ndarray([])
+                return ndarray([], [0,0])
             }
             if (this.getDimensionByName(this.bands_dimension_name).labels.length === 0) {
                 this.getDimensionByName(this.bands_dimension_name).labels = Object.keys(samples[0]) // Sets bands names as bands dimension labels

--- a/src/pg_to_evalscript/javascript_datacube/DataCube.js
+++ b/src/pg_to_evalscript/javascript_datacube/DataCube.js
@@ -181,11 +181,10 @@ class DataCube {
         // process: function, accepts `data` (labeled array) and `context` (any)
         const allCoords = this._iterateCoords(this.data.shape)
         for (let coords of allCoords) {
-            const args = coords.concat([process({
+            this.data.set(...coords, process({
                 "x": this.data.get.apply(this.data, coords),
                 context: context
-            })])
-            this.data.set.apply(this.data, args)
+            }))
         }
     }
 

--- a/src/pg_to_evalscript/javascript_datacube/DataCube.js
+++ b/src/pg_to_evalscript/javascript_datacube/DataCube.js
@@ -1,5 +1,9 @@
 class DataCube {
     constructor(data, bands_dimension_name, temporal_dimension_name, fromSamples) {
+        // data: SH samples or an ndarray
+        // bands_dimension_name: name  to use for the default bands dimension
+        // temporal_dimension_name: name to use for the default temporal dimension
+        // fromSamples: boolean, if true `data` is expected to be in format as argument `samples` passed to `evaluatePixel` in an evalscript, else ndarray
         this.TEMPORAL = "temporal"
         this.BANDS = "bands"
         this.OTHER = "other"
@@ -26,12 +30,15 @@ class DataCube {
     }
 
     makeArrayFromSamples(samples) {
+        // Converts `samples` object to ndarray of shape [number of samples, number of bands]
+        // `samples` is eqivalent to the first argument of `evaluatePixel` method in an evalscript
+        // Either object or array of objects (non-temporal and temporal scripts respectively)
         if (Array.isArray(samples)) {
             if (samples.length === 0) {
                 return ndarray([])
             }
             if (this.getDimensionByName(this.bands_dimension_name).labels.length === 0) {
-                this.getDimensionByName(this.bands_dimension_name).labels = Object.keys(samples[0])
+                this.getDimensionByName(this.bands_dimension_name).labels = Object.keys(samples[0]) // Sets bands names as bands dimension labels
             }
             let newData = []
             for (let entry of samples) {

--- a/src/pg_to_evalscript/javascript_datacube/DataCube.js
+++ b/src/pg_to_evalscript/javascript_datacube/DataCube.js
@@ -159,37 +159,6 @@ class DataCube {
         this.data = ndarray(this.data.data, this.data.shape)
     }
 
-    _select(arr, coordArr) {
-        // coordArr: 1D list of n coordinates. If m-th place has `null`, the entire axis is included and the dimension is kept
-        function coordInSlice(c1, sliceArr) {
-            return sliceArr.every((e, i) => e === null || e === c1[i])
-        }
-        return this._iter(arr, (a, coords) => {
-            if (coordInSlice(coords, coordArr)) {
-                return a
-            }
-        }, coords => coords.length >= coordArr.length || coordArr[coords.length] === null ? false : true)
-    }
-
-    _set(arr, vals, coordArr) {
-        // Set values at coordArr
-        function coordInSlice(c1, sliceArr) {
-            return c1.length === sliceArr.length && sliceArr.every((e, i) => e === null || e === c1[i])
-        }
-        const exec_set = (a, coords) => {
-            if (coordInSlice(coords, coordArr)) {
-                let valueToSet;
-                if (Array.isArray(vals)) {
-                    valueToSet = this._select(vals, coordArr.map((c, i) => c === null ? coords[i] : null).filter(c => c !== null))
-                } else {
-                    valueToSet = vals
-                }
-                return valueToSet
-            }
-            return a
-        }
-        return this._iter(arr, exec_set)
-    }
 
     _filter(dim, coordArr) {
         const shape = this.data.shape

--- a/src/pg_to_evalscript/javascript_datacube/DataCube.js
+++ b/src/pg_to_evalscript/javascript_datacube/DataCube.js
@@ -1,9 +1,9 @@
 class DataCube {
+    // data: SH samples or an ndarray
+    // bands_dimension_name: name  to use for the default bands dimension
+    // temporal_dimension_name: name to use for the default temporal dimension
+    // fromSamples: boolean, if true `data` is expected to be in format as argument `samples` passed to `evaluatePixel` in an evalscript, else ndarray
     constructor(data, bands_dimension_name, temporal_dimension_name, fromSamples) {
-        // data: SH samples or an ndarray
-        // bands_dimension_name: name  to use for the default bands dimension
-        // temporal_dimension_name: name to use for the default temporal dimension
-        // fromSamples: boolean, if true `data` is expected to be in format as argument `samples` passed to `evaluatePixel` in an evalscript, else ndarray
         this.TEMPORAL = "temporal"
         this.BANDS = "bands"
         this.OTHER = "other"
@@ -29,10 +29,10 @@ class DataCube {
         return this.dimensions.find(d => d.name === name)
     }
 
+    // Converts `samples` object to ndarray of shape [number of samples, number of bands]
+    // `samples` is eqivalent to the first argument of `evaluatePixel` method in an evalscript
+    // Either object or array of objects (non-temporal and temporal scripts respectively)
     makeArrayFromSamples(samples) {
-        // Converts `samples` object to ndarray of shape [number of samples, number of bands]
-        // `samples` is eqivalent to the first argument of `evaluatePixel` method in an evalscript
-        // Either object or array of objects (non-temporal and temporal scripts respectively)
         if (Array.isArray(samples)) {
             if (samples.length === 0) {
                 return ndarray([], [0,0])
@@ -121,9 +121,9 @@ class DataCube {
         return [...shape, ...flattenedData];
     }
 
+    // reducer: function, accepts `data` (labeled array) and `context` (any)
+    // dimension: string, name of one of the existing dimensions
     reduceByDimension(reducer, dimension, context) {
-        // reducer: function, accepts `data` (labeled array) and `context` (any)
-        // dimension: string, name of one of the existing dimensions
         const data = this.data
         const axis = this.dimensions.findIndex(e => e.name === dimension)
         const labels = this.dimensions[axis].labels
@@ -176,9 +176,8 @@ class DataCube {
         this.data = ndarray(newData, shape)
     }
 
-
+    // process: function, accepts `data` (labeled array) and `context` (any)
     apply(process, context) {
-        // process: function, accepts `data` (labeled array) and `context` (any)
         const allCoords = this._iterateCoords(this.data.shape)
         for (let coords of allCoords) {
             this.data.set(...coords, process({
@@ -188,10 +187,10 @@ class DataCube {
         }
     }
 
+    // Generator that visits all coordinates of array with `shape`, keeping nullAxes `null`
+    // shape: sizes of dimensions
+    // nullAxes: array with axes that should be kept null
     * _iterateCoords(shape, nullAxes=[]) {
-        // Generator that visits all coordinates of array with `shape`, keeping nullAxes `null`
-        // shape: sizes of dimensions
-        // nullAxes: array with axes that should be kept null
         const cumulatives = fill(shape.slice(), 0);
         const coords = shape.slice();
         for (let axis of nullAxes) {

--- a/src/pg_to_evalscript/javascript_processes/merge_cubes.js
+++ b/src/pg_to_evalscript/javascript_processes/merge_cubes.js
@@ -11,7 +11,7 @@ function merge_cubes(arguments) {
   }
 
   if (overlap_resolver && context) {
-    overlap_resolver.context = { ...context, ...overlap_resolver.context };
+    overlap_resolver.context = Object.assign({}, context, overlap_resolver.context);
   }
 
   for (let dimension of cube1.dimensions) {

--- a/src/pg_to_evalscript/node.py
+++ b/src/pg_to_evalscript/node.py
@@ -170,7 +170,8 @@ function reduce_dimension(arguments) {{
     }}
 
     {self.load_process_code()}
-    return reduce_dimension({{...arguments,reducer:reducer}});  
+    arguments['reducer'] = reducer;
+    return reduce_dimension(arguments);  
 }}
 """
 
@@ -238,7 +239,8 @@ function apply(arguments) {{
     }}
 
     {self.load_process_code()}
-    return apply({{...arguments,process:process}});
+    arguments['process'] = process;
+    return apply(arguments);
 
 }}
 """

--- a/tests/benchmark.py
+++ b/tests/benchmark.py
@@ -2,7 +2,7 @@ import json
 
 from pg_to_evalscript import convert_from_process_graph
 
-from utils import get_process_graph_json, run_javacript
+from utils import get_process_graph_json, run_javascript
 
 
 def run_benchmark(pg_name, size):
@@ -23,7 +23,7 @@ def run_benchmark(pg_name, size):
     }}
     console.timeEnd("{test_name}")
     """
-    print(run_javacript(code).decode("utf-8").strip())
+    print(run_javascript(code).decode("utf-8").strip())
 
 
 if __name__ == "__main__":

--- a/tests/integration_tests/test_integration.py
+++ b/tests/integration_tests/test_integration.py
@@ -30,8 +30,8 @@ from tests.utils import (
             [{"B01": 0.5, "B02": 0.75}, {"B01": 0, "B02": 1}, {"B01": -3, "B02": 4}, {"B01": None, "B02": None}],
             [1, 1.5, 0, 2, 0, 2, None, None],
         ),
-        ("test_graph_1", [], [None]),
-        ("test_mean_of_mean", [{"B04": 0, "B08":1}, {"B04":2, "B08":3}, {"B04":3, "B08":5}, {"B04":1, "B08": 4}], [2.375]),
+        ("test_graph_1", [], []),
+        ("test_mean_of_mean", [{"B04": 0, "B08":1}, {"B04":2, "B08":3}, {"B04":3, "B08":5}, {"B04":1, "B08": 4}], 2.375),
         (
             "test_count_with_condition",
             [{"B01": 0, "B02": 1}, {"B01": 2, "B02": 3}, {"B01": 4, "B02": 5}, {"B01": None, "B02": None}],
@@ -57,6 +57,7 @@ def test_convertable_process_graphs(pg_name, example_input, expected_output):
     assert len(result) == 1 and result[0]["invalid_node_id"] is None
 
     evalscript = result[0]["evalscript"].write()
+
     output = run_evalscript(evalscript, example_input)
     output = json.loads(output)
     

--- a/tests/unit_tests/test_datacube.py
+++ b/tests/unit_tests/test_datacube.py
@@ -7,8 +7,8 @@ from tests.utils import load_datacube_code, with_stdout_call, run_javascript
 
 @pytest.fixture
 def datacube_code():
-    def wrapped(samples):
-        return load_datacube_code() + f"\nconst datacube = new DataCube({json.dumps(samples)}, 'b', 't', true)"
+    def wrapped(samples, from_samples=True, json_samples=True):
+        return load_datacube_code() + f"\nconst datacube = new DataCube({json.dumps(samples) if json_samples else samples}, 'b', 't', {json.dumps(from_samples)})"
 
     return wrapped
 
@@ -23,6 +23,89 @@ def datacube_code():
 )
 def test_makeArrayFromSamples(datacube_code, example_samples, expected_data, expected_shape):
     testing_code = datacube_code(example_samples) + with_stdout_call("datacube")
+    output = run_javascript(testing_code)
+    output = json.loads(output)
+    assert output["data"]["data"] == expected_data
+    assert output["data"]["shape"] == expected_shape
+
+
+@pytest.mark.parametrize(
+    "shape,null_axes,expected_coords",
+    [
+        ([2,2], [], [[0,0],[0,1],[1,0],[1,1]]),
+        ([1], [], [[0]]),
+        ([3], [], [[0],[1],[2]]),
+        ([2,2,2], [], [[0,0,0],[0,0,1],[0,1,0],[0,1,1],[1,0,0],[1,0,1],[1,1,0],[1,1,1]]),
+        ([2,2], [0], [[None,0],[None,1]]),
+        ([2,2], [1], [[0,None],[1,None]]),
+        ([2,2], [0,1], [[None,None]]),
+        ([2,2,2], [0,1,2], [[None,None,None]]),
+        ([2,2,2], [0,1], [[None,None,0],[None,None,1]]),
+        ([2,2,2], [0,2], [[None,0,None],[None,1,None]]),
+        ([2,2,2], [1], [[0,None,0],[0,None,1],[1,None,0],[1,None,1]]),
+        ([2,2,2], [2], [[0,0,None],[0,1,None],[1,0,None],[1,1,None]]),
+    ],
+)
+def test_iterateCoords(datacube_code, shape, null_axes, expected_coords):
+    testing_code = datacube_code([]) +  f"\nfor(let c of datacube._iterateCoords({json.dumps(shape)}, {json.dumps(null_axes)})) {{console.log(c)}}"
+    output = run_javascript(testing_code).decode("utf-8")
+    coords = output.strip().split("\n")
+
+    for i,coord in enumerate(coords):
+        coord = json.loads(coord)
+        assert coord in expected_coords
+        expected_coords.remove(coord)
+
+    assert len(expected_coords) == 0
+
+
+@pytest.mark.parametrize(
+    "example_data,expected_data_shape,dimensions,dimension_to_reduce,expected_data,expected_shape",
+    [
+        ([1,2,3,4],[2,2],None,"b",[3,7],[2]),
+        ([1,2,3,4],[2,2],None,"t",[4,6],[2]),
+        ([1,2,3,4,5,6,7,8],[2,2,2],[{
+            "name": "x",
+            "labels": [],
+            "type": "other"
+        }, {
+            "name": "t",
+            "labels": [],
+            "type": "temporal"
+        }, {
+            "name": "b",
+            "labels": [],
+            "type": "bands"
+        }],"b",[3,7,11,15],[2,2]),([1,2,3,4,5,6,7,8],[2,2,2],[{
+            "name": "x",
+            "labels": [],
+            "type": "other"
+        }, {
+            "name": "t",
+            "labels": [],
+            "type": "temporal"
+        }, {
+            "name": "b",
+            "labels": [],
+            "type": "bands"
+        }],"t",[4,6,12,14],[2,2]),([1,2,3,4,5,6,7,8],[2,2,2],[{
+            "name": "x",
+            "labels": [],
+            "type": "other"
+        }, {
+            "name": "t",
+            "labels": [],
+            "type": "temporal"
+        }, {
+            "name": "b",
+            "labels": [],
+            "type": "bands"
+        }],"x",[6,8,10,12],[2,2])
+    ],
+)
+def test_reduceByDimension(datacube_code,example_data,expected_data_shape,dimensions,dimension_to_reduce,expected_data,expected_shape):
+    reducer = "({data}) => data.reduce((a, b) => a + b, 0)"
+    testing_code = datacube_code(f"ndarray({example_data},{expected_data_shape})", from_samples=False, json_samples=False) + (f"\ndatacube.dimensions = {json.dumps(dimensions)}" if dimensions else "") + f"\ndatacube.reduceByDimension({reducer},'{dimension_to_reduce}');" + with_stdout_call("datacube")
     output = run_javascript(testing_code)
     output = json.loads(output)
     assert output["data"]["data"] == expected_data

--- a/tests/unit_tests/test_datacube.py
+++ b/tests/unit_tests/test_datacube.py
@@ -1,0 +1,29 @@
+import json
+
+import pytest
+
+from tests.utils import load_datacube_code, with_stdout_call, run_javascript
+
+
+@pytest.fixture
+def datacube_code():
+    def wrapped(samples):
+        return load_datacube_code() + f"\nconst datacube = new DataCube({json.dumps(samples)}, 'b', 't', true)"
+
+    return wrapped
+
+
+@pytest.mark.parametrize(
+    "example_samples,expected_data,expected_shape",
+    [
+        ([{"B01": 1, "B02": 2}, {"B01": 3, "B02": 4}], [1, 2, 3, 4], [2, 2]),
+        ({"B01": 1, "B02": 2}, [1, 2], [1, 2]),
+        ([{"B01": 1, "B02": 2, "B03": 3, "B04": 4}], [1, 2, 3, 4], [1, 4]),
+    ],
+)
+def test_makeArrayFromSamples(datacube_code, example_samples, expected_data, expected_shape):
+    testing_code = datacube_code(example_samples) + with_stdout_call("datacube")
+    output = run_javascript(testing_code)
+    output = json.loads(output)
+    assert output["data"]["data"] == expected_data
+    assert output["data"]["shape"] == expected_shape

--- a/tests/unit_tests/test_datacube.py
+++ b/tests/unit_tests/test_datacube.py
@@ -144,3 +144,22 @@ def test_apply(datacube_code, example_data, example_data_shape, expected_data):
     output = run_javascript(testing_code)
     output = json.loads(output)
     assert output["data"]["data"] == expected_data
+
+
+@pytest.mark.parametrize(
+    "example_data,example_data_shape,expected_data",
+    [
+        ([1, 2, 3, 4], [2, 2], [1, 2, 3, 4]),
+        ([1, 2, 3, 4], [4], [1, 2, 3, 4]),
+        ([1, 2, 3, 4, 5, 6, 7, 8], [2, 2, 2], [1, 2, 3, 4, 5, 6, 7, 8]),
+        ([1], [], 1),
+    ],
+)
+def test_flattenToArray(datacube_code, example_data, example_data_shape, expected_data):
+    testing_code = datacube_code(
+        f"ndarray({example_data},{example_data_shape})", from_samples=False, json_samples=False
+    ) + with_stdout_call("datacube.flattenToArray()")
+    output = run_javascript(testing_code).decode("utf-8")
+    output = json.loads(output)
+
+    assert output == expected_data

--- a/tests/unit_tests/test_datacube.py
+++ b/tests/unit_tests/test_datacube.py
@@ -123,3 +123,24 @@ def test_reduceByDimension(
     output = json.loads(output)
     assert output["data"]["data"] == expected_data
     assert output["data"].get("shape") == expected_shape
+
+
+@pytest.mark.parametrize(
+    "example_data,example_data_shape,expected_data",
+    [
+        ([1, 2, 3, 4], [2, 2], [3, 6, 9, 12]),
+        ([1, 2, 3, 4], [4], [3, 6, 9, 12]),
+        ([1], [], [3]),
+        ([1, 2, 3, 4, 5, 6, 7, 8], [2, 2, 2], [3, 6, 9, 12, 15, 18, 21, 24]),
+    ],
+)
+def test_apply(datacube_code, example_data, example_data_shape, expected_data):
+    process = "({x}) => x * 3"
+    testing_code = (
+        datacube_code(f"ndarray({example_data},{example_data_shape})", from_samples=False, json_samples=False)
+        + f"\ndatacube.apply({process});"
+        + with_stdout_call("datacube")
+    )
+    output = run_javascript(testing_code)
+    output = json.loads(output)
+    assert output["data"]["data"] == expected_data

--- a/tests/unit_tests/test_datacube.py
+++ b/tests/unit_tests/test_datacube.py
@@ -8,7 +8,10 @@ from tests.utils import load_datacube_code, with_stdout_call, run_javascript
 @pytest.fixture
 def datacube_code():
     def wrapped(samples, from_samples=True, json_samples=True):
-        return load_datacube_code() + f"\nconst datacube = new DataCube({json.dumps(samples) if json_samples else samples}, 'b', 't', {json.dumps(from_samples)})"
+        return (
+            load_datacube_code()
+            + f"\nconst datacube = new DataCube({json.dumps(samples) if json_samples else samples}, 'b', 't', {json.dumps(from_samples)})"
+        )
 
     return wrapped
 
@@ -32,26 +35,29 @@ def test_makeArrayFromSamples(datacube_code, example_samples, expected_data, exp
 @pytest.mark.parametrize(
     "shape,null_axes,expected_coords",
     [
-        ([2,2], [], [[0,0],[0,1],[1,0],[1,1]]),
+        ([2, 2], [], [[0, 0], [0, 1], [1, 0], [1, 1]]),
         ([1], [], [[0]]),
-        ([3], [], [[0],[1],[2]]),
-        ([2,2,2], [], [[0,0,0],[0,0,1],[0,1,0],[0,1,1],[1,0,0],[1,0,1],[1,1,0],[1,1,1]]),
-        ([2,2], [0], [[None,0],[None,1]]),
-        ([2,2], [1], [[0,None],[1,None]]),
-        ([2,2], [0,1], [[None,None]]),
-        ([2,2,2], [0,1,2], [[None,None,None]]),
-        ([2,2,2], [0,1], [[None,None,0],[None,None,1]]),
-        ([2,2,2], [0,2], [[None,0,None],[None,1,None]]),
-        ([2,2,2], [1], [[0,None,0],[0,None,1],[1,None,0],[1,None,1]]),
-        ([2,2,2], [2], [[0,0,None],[0,1,None],[1,0,None],[1,1,None]]),
+        ([3], [], [[0], [1], [2]]),
+        ([2, 2, 2], [], [[0, 0, 0], [0, 0, 1], [0, 1, 0], [0, 1, 1], [1, 0, 0], [1, 0, 1], [1, 1, 0], [1, 1, 1]]),
+        ([2, 2], [0], [[None, 0], [None, 1]]),
+        ([2, 2], [1], [[0, None], [1, None]]),
+        ([2, 2], [0, 1], [[None, None]]),
+        ([2, 2, 2], [0, 1, 2], [[None, None, None]]),
+        ([2, 2, 2], [0, 1], [[None, None, 0], [None, None, 1]]),
+        ([2, 2, 2], [0, 2], [[None, 0, None], [None, 1, None]]),
+        ([2, 2, 2], [1], [[0, None, 0], [0, None, 1], [1, None, 0], [1, None, 1]]),
+        ([2, 2, 2], [2], [[0, 0, None], [0, 1, None], [1, 0, None], [1, 1, None]]),
     ],
 )
 def test_iterateCoords(datacube_code, shape, null_axes, expected_coords):
-    testing_code = datacube_code([]) +  f"\nfor(let c of datacube._iterateCoords({json.dumps(shape)}, {json.dumps(null_axes)})) {{console.log(c)}}"
+    testing_code = (
+        datacube_code([])
+        + f"\nfor(let c of datacube._iterateCoords({json.dumps(shape)}, {json.dumps(null_axes)})) {{console.log(c)}}"
+    )
     output = run_javascript(testing_code).decode("utf-8")
     coords = output.strip().split("\n")
 
-    for i,coord in enumerate(coords):
+    for i, coord in enumerate(coords):
         coord = json.loads(coord)
         assert coord in expected_coords
         expected_coords.remove(coord)
@@ -62,51 +68,58 @@ def test_iterateCoords(datacube_code, shape, null_axes, expected_coords):
 @pytest.mark.parametrize(
     "example_data,expected_data_shape,dimensions,dimension_to_reduce,expected_data,expected_shape",
     [
-        ([1,2,3,4],[2,2],None,"b",[3,7],[2]),
-        ([1,2,3,4],[2,2],None,"t",[4,6],[2]),
-        ([1,2,3,4,5,6,7,8],[2,2,2],[{
-            "name": "x",
-            "labels": [],
-            "type": "other"
-        }, {
-            "name": "t",
-            "labels": [],
-            "type": "temporal"
-        }, {
-            "name": "b",
-            "labels": [],
-            "type": "bands"
-        }],"b",[3,7,11,15],[2,2]),([1,2,3,4,5,6,7,8],[2,2,2],[{
-            "name": "x",
-            "labels": [],
-            "type": "other"
-        }, {
-            "name": "t",
-            "labels": [],
-            "type": "temporal"
-        }, {
-            "name": "b",
-            "labels": [],
-            "type": "bands"
-        }],"t",[4,6,12,14],[2,2]),([1,2,3,4,5,6,7,8],[2,2,2],[{
-            "name": "x",
-            "labels": [],
-            "type": "other"
-        }, {
-            "name": "t",
-            "labels": [],
-            "type": "temporal"
-        }, {
-            "name": "b",
-            "labels": [],
-            "type": "bands"
-        }],"x",[6,8,10,12],[2,2])
+        ([1, 2, 3, 4], [2, 2], None, "b", [3, 7], [2]),
+        ([1, 2, 3, 4], [2, 2], None, "t", [4, 6], [2]),
+        (
+            [1, 2, 3, 4, 5, 6, 7, 8],
+            [2, 2, 2],
+            [
+                {"name": "x", "labels": [], "type": "other"},
+                {"name": "t", "labels": [], "type": "temporal"},
+                {"name": "b", "labels": [], "type": "bands"},
+            ],
+            "b",
+            [3, 7, 11, 15],
+            [2, 2],
+        ),
+        (
+            [1, 2, 3, 4, 5, 6, 7, 8],
+            [2, 2, 2],
+            [
+                {"name": "x", "labels": [], "type": "other"},
+                {"name": "t", "labels": [], "type": "temporal"},
+                {"name": "b", "labels": [], "type": "bands"},
+            ],
+            "t",
+            [4, 6, 12, 14],
+            [2, 2],
+        ),
+        (
+            [1, 2, 3, 4, 5, 6, 7, 8],
+            [2, 2, 2],
+            [
+                {"name": "x", "labels": [], "type": "other"},
+                {"name": "t", "labels": [], "type": "temporal"},
+                {"name": "b", "labels": [], "type": "bands"},
+            ],
+            "x",
+            [6, 8, 10, 12],
+            [2, 2],
+        ),
+        ([1, 2], [2], [{"name": "t", "labels": [], "type": "temporal"}], "t", [3], None),
     ],
 )
-def test_reduceByDimension(datacube_code,example_data,expected_data_shape,dimensions,dimension_to_reduce,expected_data,expected_shape):
+def test_reduceByDimension(
+    datacube_code, example_data, expected_data_shape, dimensions, dimension_to_reduce, expected_data, expected_shape
+):
     reducer = "({data}) => data.reduce((a, b) => a + b, 0)"
-    testing_code = datacube_code(f"ndarray({example_data},{expected_data_shape})", from_samples=False, json_samples=False) + (f"\ndatacube.dimensions = {json.dumps(dimensions)}" if dimensions else "") + f"\ndatacube.reduceByDimension({reducer},'{dimension_to_reduce}');" + with_stdout_call("datacube")
+    testing_code = (
+        datacube_code(f"ndarray({example_data},{expected_data_shape})", from_samples=False, json_samples=False)
+        + (f"\ndatacube.dimensions = {json.dumps(dimensions)}" if dimensions else "")
+        + f"\ndatacube.reduceByDimension({reducer},'{dimension_to_reduce}');"
+        + with_stdout_call("datacube")
+    )
     output = run_javascript(testing_code)
     output = json.loads(output)
     assert output["data"]["data"] == expected_data
-    assert output["data"]["shape"] == expected_shape
+    assert output["data"].get("shape") == expected_shape

--- a/tests/unit_tests/test_datacube.py
+++ b/tests/unit_tests/test_datacube.py
@@ -66,10 +66,8 @@ def test_iterateCoords(datacube_code, shape, null_axes, expected_coords):
 
 
 @pytest.mark.parametrize(
-    "example_data,expected_data_shape,dimensions,dimension_to_reduce,expected_data,expected_shape",
+    "example_data,example_data_shape,dimensions,dimension_to_reduce,expected_data,expected_shape",
     [
-        ([1, 2, 3, 4], [2, 2], None, "b", [3, 7], [2]),
-        ([1, 2, 3, 4], [2, 2], None, "t", [4, 6], [2]),
         (
             [1, 2, 3, 4, 5, 6, 7, 8],
             [2, 2, 2],
@@ -110,11 +108,11 @@ def test_iterateCoords(datacube_code, shape, null_axes, expected_coords):
     ],
 )
 def test_reduceByDimension(
-    datacube_code, example_data, expected_data_shape, dimensions, dimension_to_reduce, expected_data, expected_shape
+    datacube_code, example_data, example_data_shape, dimensions, dimension_to_reduce, expected_data, expected_shape
 ):
     reducer = "({data}) => data.reduce((a, b) => a + b, 0)"
     testing_code = (
-        datacube_code(f"ndarray({example_data},{expected_data_shape})", from_samples=False, json_samples=False)
+        datacube_code(f"ndarray({example_data},{example_data_shape})", from_samples=False, json_samples=False)
         + (f"\ndatacube.dimensions = {json.dumps(dimensions)}" if dimensions else "")
         + f"\ndatacube.reduceByDimension({reducer},'{dimension_to_reduce}');"
         + with_stdout_call("datacube")

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -11,10 +11,12 @@ def get_process_graph_json(name):
         return json.load(f)
 
 
+def with_stdout_call(code):
+    return f"\nprocess.stdout.write(JSON.stringify({code}))"
+
+
 def get_execute_test_script(example_input):
-    return f"""
-process.stdout.write(JSON.stringify(evaluatePixel({json.dumps(example_input)})));
-"""
+    return with_stdout_call(json.dumps(example_input))
 
 
 def run_evalscript(evalscript, example_input):
@@ -23,13 +25,11 @@ def run_evalscript(evalscript, example_input):
 
 def run_process(process_code, process_name, example_input):
     input_arguments = json.dumps(example_input) if type(example_input) is dict else example_input
-    return run_javascript(
-        process_code + f"process.stdout.write(JSON.stringify({process_name}({input_arguments})))"
-    )
+    return run_javascript(process_code + with_stdout_call(f"{process_name}({input_arguments})"))
 
 
 def get_evalscript_input_object(evalscript):
-    return json.loads(run_javascript(evalscript + f"\nprocess.stdout.write(JSON.stringify(setup()))"))
+    return json.loads(run_javascript(evalscript + with_stdout_call("setup()")))
 
 
 def run_javascript(javascript_code):

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -16,7 +16,7 @@ def with_stdout_call(code):
 
 
 def get_execute_test_script(example_input):
-    return with_stdout_call(json.dumps(example_input))
+    return with_stdout_call(f"evaluatePixel({json.dumps(example_input)})")
 
 
 def run_evalscript(evalscript, example_input):


### PR DESCRIPTION
Closes https://git.sinergise.com/team-6/openeo-platform/-/issues/124
* remove unnecessary methods
* add comments
* simplify `reduceByDimension` and `apply`
* fix bugs in  `reduceByDimension` when data had more than 2 dimensions
* simplify repeated code for `process.stdout.write`
* add tests for DataCube methods
* handle no data and scalars better
* fix other issues

Changes in `integration tests`:
1. Reducing all dimensions now correctly returns a scalar, not an array: `[2.375]` => `2.375`
2. No data (samples=`[]`) and running reduce on it returned `[None]`. This imo gives an impression that there was data and a values was calculated to be `None`. Changed so that it is an empty array.