### PR TITLE
Fix issue with spread operator for objects

### DIFF
--- a/src/pg_to_evalscript/javascript_processes/merge_cubes.js
+++ b/src/pg_to_evalscript/javascript_processes/merge_cubes.js
@@ -11,7 +11,7 @@ function merge_cubes(arguments) {
   }
 
   if (overlap_resolver && context) {
-    overlap_resolver.context = { ...context, ...overlap_resolver.context };
+    overlap_resolver.context = Object.assign(context, overlap_resolver.context);
   }
 
   for (let dimension of cube1.dimensions) {

--- a/src/pg_to_evalscript/javascript_processes/merge_cubes.js
+++ b/src/pg_to_evalscript/javascript_processes/merge_cubes.js
@@ -11,7 +11,7 @@ function merge_cubes(arguments) {
   }
 
   if (overlap_resolver && context) {
-    overlap_resolver.context = Object.assign(context, overlap_resolver.context);
+    overlap_resolver.context = Object.assign({}, context, overlap_resolver.context);
   }
 
   for (let dimension of cube1.dimensions) {

--- a/src/pg_to_evalscript/node.py
+++ b/src/pg_to_evalscript/node.py
@@ -170,7 +170,8 @@ function reduce_dimension(arguments) {{
     }}
 
     {self.load_process_code()}
-    return reduce_dimension({{...arguments,reducer:reducer}});  
+    arguments['reducer'] = reducer;
+    return reduce_dimension(arguments);  
 }}
 """
 
@@ -238,7 +239,8 @@ function apply(arguments) {{
     }}
 
     {self.load_process_code()}
-    return apply({{...arguments,process:process}});
+    arguments['process'] = process;
+    return apply(arguments);
 
 }}
 """


### PR DESCRIPTION
This is not supported by V8 version `7.4` that SH is using and the evalscripts fail. 

I guess we'll have to run the evalscripts in V8 instead of node at some point. I tried nodejs14 which supposedly uses V8 7.4 but it passed.

