### PR TITLE
Fix issue with failing Pypi publish

### DIFF
--- a/.github/workflows/publish_to_pypi.yml
+++ b/.github/workflows/publish_to_pypi.yml
@@ -37,3 +37,4 @@ jobs:
       with:
         user: __token__
         password: ${{ secrets.PYPI_API_TOKEN }}
+        verbose: true

--- a/setup.cfg
+++ b/setup.cfg
@@ -5,3 +5,7 @@ packages=find:
 
 [options.packages.find]
 where=src
+
+[metadata]
+long_description = file: README.md
+long_description_content_type = text/markdown


### PR DESCRIPTION
Publishing on Pypi failed:

https://github.com/openEOPlatform/openeo-pg-evalscript-converter/runs/6424273982?check_suite_focus=true

This PR should fix that. No idea what caused it to fail all of a sudden.

Side effect is that we'll now have README as the description on Pypi (https://pypi.org/project/pg-to-evalscript/0.2.2rc2/)