### PR TITLE
Use older version of Node to run tests and remove object literals spr…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,11 @@
-FROM nikolaik/python-nodejs:python3.7-nodejs6
+FROM python:3.8.13
 
 ADD . .
+
+SHELL ["/bin/bash", "--login", "-c"]
+
+RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.35.3/install.sh | bash
+RUN nvm install 8.2.1
 
 RUN pip3 install --upgrade pip
 RUN pip3  install -e .
@@ -8,4 +13,4 @@ RUN pip3 install pytest
 
 WORKDIR /tests/
 
-CMD ["pytest", "-x"]
+CMD pytest -x

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM nikolaik/python-nodejs:latest
+FROM nikolaik/python-nodejs:python3.7-nodejs6
 
 ADD . .
 
@@ -8,4 +8,4 @@ RUN pip3 install pytest
 
 WORKDIR /tests/
 
-CMD ["pytest"]
+CMD ["pytest", "-x"]

--- a/README.md
+++ b/README.md
@@ -230,7 +230,7 @@ docker run tests
 
 #### Directly
 
-Tests require a NodeJS environment. 
+Tests require a NodeJS environment. Use version =< 8.2.1 to match Sentinel Hub behaviour.
 
 ```
 pipenv install

--- a/src/pg_to_evalscript/node.py
+++ b/src/pg_to_evalscript/node.py
@@ -218,7 +218,8 @@ function overlap_resolver(arguments) {{
 function merge_cubes(arguments) {{
     {overlap_resolver_code}
     {self.load_process_code()}
-    return merge_cubes({{...arguments, overlap_resolver: overlap_resolver }});
+    arguments['overlap_resolver'] = overlap_resolver;
+    return merge_cubes(arguments);
 }}
 """
 
@@ -282,7 +283,8 @@ function apply_dimension(arguments) {{
     }}
 
     {self.load_process_code()}
-    return apply_dimension({{...arguments, process}})
+    arguments['process'] = process;
+    return apply_dimension(arguments)
 }}
 """
 
@@ -376,7 +378,8 @@ function aggregate_temporal(arguments) {{
     }}
 
     {self.load_process_code()}
-    return aggregate_temporal({{...arguments, reducer: reducer}});
+    arguments['reducer'] = reducer;
+    return aggregate_temporal(arguments);
 }}
 """
 

--- a/tests/unit_tests/test_add_dimension.py
+++ b/tests/unit_tests/test_add_dimension.py
@@ -83,7 +83,7 @@ def test_add_dimension(add_dimension_process_code, example_input, expected_outpu
         load_datacube_code()
         + f"const cube = new DataCube({example_input['data']}, 'bands_name', 'temporal_name', true);"
     )
-    process_arguments = f"{{...{json.dumps(example_input)}, 'data': cube}}"
+    process_arguments = f"Object.assign({json.dumps(example_input)}, {{'data': cube}})"
     output = run_process(
         add_dimension_process_code + additional_js_code_to_run,
         "add_dimension",
@@ -152,7 +152,7 @@ def test_add_dimension_exceptions(add_dimension_process_code, example_input, rai
         load_datacube_code()
         + f"const cube = new DataCube({example_input['data']}, 'bands_name', 'temporal_name', true);"
     )
-    process_arguments = f"{{...{json.dumps(example_input)}, 'data': cube}}"
+    process_arguments = f"Object.assign({json.dumps(example_input)}, {{'data': cube}})"
     run_input_validation(
         add_dimension_process_code + additional_js_code_to_run,
         "add_dimension",

--- a/tests/unit_tests/test_aggregate_temporal.py
+++ b/tests/unit_tests/test_aggregate_temporal.py
@@ -184,7 +184,7 @@ def test_aggregate_temporal(aggregate_temporal_process_code, data, scenes, examp
         load_datacube_code() + f"const cube = new DataCube({data}, 'bands_name', 'temporal_name', true, [], {scenes});"
     )
     process_arguments = (
-        f"{{...{json.dumps(example_input)}, 'data': cube, 'scenes': {scenes}, 'reducer': {example_input['reducer']}}}"
+        f"Object.assign({json.dumps(example_input)}, {{'data': cube, 'scenes': {scenes}, 'reducer': {example_input['reducer']}}})"
     )
     output = run_process(
         aggregate_temporal_process_code + additional_js_code_to_run,
@@ -287,7 +287,7 @@ def test_aggregate_temporal_exceptions(
         load_datacube_code() + f"const cube = new DataCube({data}, 'bands_name', 'temporal_name', true, [], {scenes});"
     )
     process_arguments = (
-        f"{{...{json.dumps(example_input)}, 'data': cube, 'scenes': {scenes}, 'reducer': {example_input['reducer']}}}"
+        f"Object.assign({json.dumps(example_input)}, {{'data': cube, 'scenes': {scenes}, 'reducer': {example_input['reducer']}}})"
     )
 
     run_input_validation(

--- a/tests/unit_tests/test_apply.py
+++ b/tests/unit_tests/test_apply.py
@@ -112,7 +112,7 @@ def test_apply(apply_process_code, example_input, process, expected_output):
         load_datacube_code()
         + f"const cube = new DataCube({example_input['data']}, 'bands_name', 'temporal_name', true);"
     )
-    process_arguments = f"{{...{json.dumps(example_input)}, 'data': cube, 'process':{process}}}"
+    process_arguments = f"Object.assign{json.dumps(example_input)}, {{'data': cube, 'process':{process}}})"
     output = run_process(
         apply_process_code + additional_js_code_to_run,
         "apply",

--- a/tests/unit_tests/test_apply.py
+++ b/tests/unit_tests/test_apply.py
@@ -112,7 +112,7 @@ def test_apply(apply_process_code, example_input, process, expected_output):
         load_datacube_code()
         + f"const cube = new DataCube({example_input['data']}, 'bands_name', 'temporal_name', true);"
     )
-    process_arguments = f"Object.assign{json.dumps(example_input)}, {{'data': cube, 'process':{process}}})"
+    process_arguments = f"Object.assign({json.dumps(example_input)}, {{'data': cube, 'process':{process}}})"
     output = run_process(
         apply_process_code + additional_js_code_to_run,
         "apply",

--- a/tests/unit_tests/test_apply_dimension.py
+++ b/tests/unit_tests/test_apply_dimension.py
@@ -157,7 +157,7 @@ def test_apply_dimension(apply_dimension_process_code, example_input, expected_r
     additional_js_code_to_run = (
         load_datacube_code() + f"const cube = new DataCube({example_input['data']}, 'bands', 'temporal', true);"
     )
-    process_arguments = f"{{...{json.dumps(example_input)}, 'data': cube, 'process':{example_input['process']}}}"
+    process_arguments = f"Object.assign({json.dumps(example_input)}, {{'data': cube, 'process':{example_input['process']}}})"
     output = run_process(
         apply_dimension_process_code + additional_js_code_to_run,
         "apply_dimension",
@@ -233,9 +233,9 @@ def test_input_validation(apply_dimension_process_code, example_input, raises_ex
     cube = f"const cube = new DataCube({data}, 'bands', 'temporal', true);" if data else f"const cube=undefined;"
     additional_js_code_to_run = load_datacube_code() + cube
     if process:
-        process_arguments = f"{{...{json.dumps(example_input)}, 'data': cube, 'process':{process}}}"
+        process_arguments = f"Object.assign({json.dumps(example_input)}, {{'data': cube, 'process':{process}}})"
     else:
-        process_arguments = f"{{...{json.dumps(example_input)}, 'data': cube }}"
+        process_arguments = f"Object.assign({json.dumps(example_input)}, {{'data': cube }})"
 
     run_input_validation(
         apply_dimension_process_code + additional_js_code_to_run,

--- a/tests/unit_tests/test_array_element.py
+++ b/tests/unit_tests/test_array_element.py
@@ -39,7 +39,7 @@ def test_array_element(array_element_process_code, example_input, expected_outpu
         load_datacube_code()
         + f"const d = {json.dumps(example_input['data'])}; d.labels = {json.dumps(example_input['labels']) if 'labels' in example_input else 'undefined'};"
     )
-    process_arguments = f"{{...{json.dumps(example_input)}, 'data': d}}"
+    process_arguments = f"Object.assign({json.dumps(example_input)}, {{'data': d}})"
     output = run_process(
         array_element_process_code + additional_js_code_to_run,
         "array_element",
@@ -92,7 +92,7 @@ def test_array_element_exceptions(array_element_process_code, example_input, rai
         if "data" in example_input
         else ""
     )
-    process_arguments = f"{{...{json.dumps(example_input)}, 'data': {'d' if 'data' in example_input else 'undefined'}}}"
+    process_arguments = f"Object.assign({json.dumps(example_input)}, {{'data': {'d' if 'data' in example_input else 'undefined'}}})"
     run_input_validation(
         array_element_process_code + additional_js_code_to_run,
         "array_element",

--- a/tests/unit_tests/test_array_labels.py
+++ b/tests/unit_tests/test_array_labels.py
@@ -49,7 +49,7 @@ def test_array_labels_exceptions(array_labels_process_code, example_input, raise
         if "data" in example_input
         else ""
     )
-    process_arguments = f"{{...{json.dumps(example_input)}, 'data': {'d' if 'data' in example_input else 'undefined'}}}"
+    process_arguments = f"Object.assign({json.dumps(example_input)}, {{'data': {'d' if 'data' in example_input else 'undefined'}}})"
     run_input_validation(
         array_labels_process_code + additional_js_code_to_run,
         "array_labels",

--- a/tests/unit_tests/test_filter_bands.py
+++ b/tests/unit_tests/test_filter_bands.py
@@ -74,7 +74,7 @@ def test_filter_bands(filter_bands_process_code, example_input, expected_output)
         load_datacube_code()
         + f"const cube = new DataCube({example_input['data']}, 'bands_name', 'temporal_name', true);"
     )
-    process_arguments = f"{{...{json.dumps(example_input)}, 'data': cube}}"
+    process_arguments = f"Object.assign({json.dumps(example_input)}, {{'data': cube}})"
     output = run_process(
         filter_bands_process_code + additional_js_code_to_run,
         "filter_bands",
@@ -130,7 +130,7 @@ def test_filter_bands_exceptions(filter_bands_process_code, example_input, raise
         load_datacube_code()
         + f"const cube = new DataCube({example_input['data']}, 'bands_name', 'temporal_name', true);"
     )
-    process_arguments = f"{{...{json.dumps(example_input)}, 'data': cube}}"
+    process_arguments = f"Object.assign({json.dumps(example_input)}, {{'data': cube}})"
     run_input_validation(
         filter_bands_process_code + additional_js_code_to_run,
         "filter_bands",

--- a/tests/unit_tests/test_filter_temporal.py
+++ b/tests/unit_tests/test_filter_temporal.py
@@ -260,7 +260,7 @@ def test_filter_temporal(filter_temporal_process_code, data, scenes, example_inp
     additional_js_code_to_run = (
         load_datacube_code() + f"const cube = new DataCube({data}, 'bands_name', 'temporal_name', true, [], {scenes});"
     )
-    process_arguments = f"{{...{json.dumps(example_input)}, 'data': cube, 'scenes': {scenes}}}"
+    process_arguments = f"Object.assign({json.dumps(example_input)}, {{'data': cube, 'scenes': {scenes}}})"
     output = run_process(
         filter_temporal_process_code + additional_js_code_to_run,
         "filter_temporal",
@@ -460,7 +460,7 @@ def test_filter_temporal_exceptions(filter_temporal_process_code, example_input,
         load_datacube_code()
         + f"const cube = new DataCube({example_input['data']}, 'bands_name', 'temporal_name', true, [], {example_input['scenes']});"
     )
-    process_arguments = f"{{...{json.dumps(example_input)}, 'data': cube}}"
+    process_arguments = f"Object.assign({json.dumps(example_input)}, {{'data': cube}})"
     run_input_validation(
         filter_temporal_process_code + additional_js_code_to_run,
         "filter_temporal",

--- a/tests/unit_tests/test_ndvi.py
+++ b/tests/unit_tests/test_ndvi.py
@@ -252,7 +252,7 @@ def test_ndvi(ndvi_code, example_input, expected_output):
         load_datacube_code()
         + f"const cube = new DataCube({example_input['data']}, 'bands', 't', true, {bands_metadata});"
     )
-    process_arguments = f"{{...{json.dumps(example_input)}, 'data': cube}}"
+    process_arguments = f"Object.assign({json.dumps(example_input)}, {{'data': cube}})"
     output = run_process(ndvi_code + js_code, "ndvi", process_arguments)
     output = json.loads(output)
     assert output == expected_output
@@ -429,5 +429,5 @@ def test_input_validation(ndvi_code, example_input, additional_js_code_specific_
         + f"let cube = new DataCube({example_input['data']}, 'bands', 't', true, {bands_metadata});"
         + (additional_js_code_specific_to_case or "")
     )
-    process_arguments = f"{{...{json.dumps(example_input)}, 'data': cube}}"
+    process_arguments = f"Object.assign({json.dumps(example_input)}, {{'data': cube}})"
     run_input_validation(ndvi_code + js_code, "ndvi", process_arguments, raises_exception, error_name)

--- a/tests/unit_tests/test_order.py
+++ b/tests/unit_tests/test_order.py
@@ -4,7 +4,7 @@ import pytest
 
 from tests.utils import load_process_code, run_process, run_input_validation
 
-1,2,8,5,0,4,7,9,10,6,3
+
 @pytest.fixture
 def order_process_code():
     return load_process_code("order")

--- a/tests/unit_tests/test_order.py
+++ b/tests/unit_tests/test_order.py
@@ -4,7 +4,7 @@ import pytest
 
 from tests.utils import load_process_code, run_process, run_input_validation
 
-
+1,2,8,5,0,4,7,9,10,6,3
 @pytest.fixture
 def order_process_code():
     return load_process_code("order")
@@ -18,14 +18,14 @@ def order_process_code():
         ({"data": [6, -1, 2, 7, 4, 8, 3, 9, 9]}, [1, 2, 6, 4, 0, 3, 5, 7, 8]),
         ({"data": [6, -1, 2, 7, 4, 8, 3, 9, 9], "asc": False}, [7, 8, 5, 3, 0, 4, 6, 2, 1]),
         ({"data": [6, -1, 2, None, 7, 4, None, 8, 3, 9, 9]}, [1, 2, 8, 5, 0, 4, 7, 9, 10]),
-        ({"data": [6, -1, 2, None, 7, 4, None, 8, 3, 9, 9], "nodata": True}, [1, 2, 8, 5, 0, 4, 7, 9, 10, 3, 6]),
+        ({"data": [6, -1, 2, None, 7, 4, None, 8, 3, 9, 9], "nodata": True}, [1, 2, 8, 5, 0, 4, 7, 9, 10, 6, 3]),
         (
             {"data": [6, -1, 2, None, 7, 4, None, 8, 3, 9, 9], "asc": False, "nodata": True},
-            [9, 10, 7, 4, 0, 5, 8, 2, 1, 3, 6],
+            [10, 9, 7, 4, 0, 5, 8, 2, 1, 6, 3],
         ),
         (
             {"data": [6, -1, 2, None, 7, 4, None, 8, 3, 9, 9], "asc": False, "nodata": False},
-            [3, 6, 9, 10, 7, 4, 0, 5, 8, 2, 1],
+            [3, 6, 10, 9, 7, 4, 0, 5, 8, 2, 1],
         ),
         ({"data": ["2020-01-01T12:00:00Z", "2021-01-01T12:00:00Z", "2022-01-01T12:00:00Z"]}, [0, 1, 2]),
         ({"data": ["2022-01-01T12:00:00Z", "2021-01-01T12:00:00Z", "2020-01-01T12:00:00Z"]}, [2, 1, 0]),

--- a/tests/unit_tests/test_reduce_dimension.py
+++ b/tests/unit_tests/test_reduce_dimension.py
@@ -89,7 +89,7 @@ def test_reduce_dimension(reduce_dimension_process_code, example_input, expected
     additional_js_code_to_run = (
         load_datacube_code() + f"const cube = new DataCube({example_input['data']}, 'bands', 'temporal', true);"
     )
-    process_arguments = f"{{...{json.dumps(example_input)}, 'data': cube, 'reducer':{example_input['reducer']}}}"
+    process_arguments = f"Object.assign({json.dumps(example_input)}, {{'data': cube, 'reducer':{example_input['reducer']}}})"
     output = run_process(
         reduce_dimension_process_code + additional_js_code_to_run,
         "reduce_dimension",
@@ -166,9 +166,9 @@ def test_input_validation(reduce_dimension_process_code, example_input, raises_e
     cube = f"const cube = new DataCube({data}, 'bands', 'temporal', true);" if data else f"const cube=undefined;"
     additional_js_code_to_run = load_datacube_code() + cube
     if reducer:
-        process_arguments = f"{{...{json.dumps(example_input)}, 'data': cube, 'reducer':{reducer}}}"
+        process_arguments = f"Object.assign({json.dumps(example_input)}, {{'data': cube, 'reducer':{reducer}}})"
     else:
-        process_arguments = f"{{...{json.dumps(example_input)}, 'data': cube }}"
+        process_arguments = f"Object.assign({json.dumps(example_input)}, {{'data': cube }})"
 
     run_input_validation(
         reduce_dimension_process_code + additional_js_code_to_run,

--- a/tests/unit_tests/test_rename_labels.py
+++ b/tests/unit_tests/test_rename_labels.py
@@ -104,7 +104,7 @@ def test_rename_labels(rename_labels_process_code, example_input, expected_outpu
         load_datacube_code()
         + f"const cube = new DataCube({example_input['data']}, 'bands_name', 'temporal_name', true);"
     )
-    process_arguments = f"{{...{json.dumps(example_input)}, 'data': cube}}"
+    process_arguments = f"Object.assign({json.dumps(example_input)}, {{'data': cube}})"
     output = run_process(
         rename_labels_process_code + additional_js_code_to_run,
         "rename_labels",
@@ -221,7 +221,7 @@ def test_rename_labels_exceptions(rename_labels_process_code, example_input, rai
         load_datacube_code()
         + f"const cube = new DataCube({example_input['data']}, 'bands_name', 'temporal_name', true);"
     )
-    process_arguments = f"{{...{json.dumps(example_input)}, 'data': cube}}"
+    process_arguments = f"Object.assign({json.dumps(example_input)}, {{'data': cube}})"
     run_input_validation(
         rename_labels_process_code + additional_js_code_to_run,
         "rename_labels",


### PR DESCRIPTION
Closes https://git.sinergise.com/team-6/openeo-platform/-/issues/171

Tried using V8 directly instead, but it's much simpler to just use an older version of NodeJS. Object literal spreading was introduced in `8.3.0`, so we need to use `8.2.1`.

Unfortunartely there is no `python-nodejs` images for that combination.

Removes all the spread operators where necessary, also older version order identical elements in the opposite way (`order` process). You can check, however, that the current expected outputs in `test_order` match the output produced by evalscript on SH. 