### PR TITLE
Fix bug with execution order not being calculated correctly in some c…

### DIFF
--- a/src/pg_to_evalscript/process_graph_utils.py
+++ b/src/pg_to_evalscript/process_graph_utils.py
@@ -61,8 +61,6 @@ def get_execution_order(dependencies, dependents):
     execution_order = [entry_point for entry_point in entry_points]
     remaining_nodes = set(dependencies.keys()).difference(execution_order)
 
-    i = 0
-
     while len(remaining_nodes) > 0:
         for node in execution_order:
             for node_dependency in dependents[node]:

--- a/src/pg_to_evalscript/process_graph_utils.py
+++ b/src/pg_to_evalscript/process_graph_utils.py
@@ -64,9 +64,6 @@ def get_execution_order(dependencies, dependents):
     i = 0
 
     while len(remaining_nodes) > 0:
-        if i > 20:
-            break
-        i += 1
         for node in execution_order:
             for node_dependency in dependents[node]:
                 if node_dependency in execution_order:
@@ -76,9 +73,6 @@ def get_execution_order(dependencies, dependents):
                 if can_be_executed:
                     execution_order.append(node_dependency)
                     remaining_nodes.remove(node_dependency)
-
-                else:
-                    break
     return execution_order
 
 

--- a/tests/tests_main/test_dependents.py
+++ b/tests/tests_main/test_dependents.py
@@ -3,7 +3,6 @@ from collections import defaultdict
 import pytest
 
 from pg_to_evalscript.process_graph_utils import get_execution_order
-from tests.utils import get_process_graph_json
 
 
 def generate_default_dict_from_dict(d):

--- a/tests/tests_main/test_dependents.py
+++ b/tests/tests_main/test_dependents.py
@@ -13,7 +13,7 @@ def generate_default_dict_from_dict(d):
 
 
 @pytest.mark.parametrize(
-    "dependency_graph,dependents,expected_exection_order",
+    "dependency_graph,dependents,possible_exection_orders",
     [
         (
             generate_default_dict_from_dict(
@@ -33,7 +33,7 @@ def generate_default_dict_from_dict(d):
                     "resample": {"saveresult1"},
                 }
             ),
-            ["loadco1", "filter_every_second", "rename_labels1", "resample", "saveresult1"],
+            [["loadco1", "filter_every_second", "rename_labels1", "resample", "saveresult1"]],
         ),
         (
             generate_default_dict_from_dict(
@@ -53,10 +53,35 @@ def generate_default_dict_from_dict(d):
                     "resample": {"saveresult1"},
                 }
             ),
-            ["loadco1", "filter_every_second", "rename_labels1", "resample", "saveresult1"],
+            [["loadco1", "filter_every_second", "rename_labels1", "resample", "saveresult1"]],
+        ),
+        (
+            generate_default_dict_from_dict(
+                {
+                    "loadco1": set(),
+                    "filter_every_second": {"loadco1"},
+                    "filter_labels": {"loadco1"},
+                    "rename_labels1": {"filter_every_second", "filter_labels"},
+                    "resample": {"rename_labels1", "loadco1"},
+                    "saveresult1": {"resample"},
+                }
+            ),
+            generate_default_dict_from_dict(
+                {
+                    "loadco1": {"filter_every_second", "resample", "filter_labels"},
+                    "filter_every_second": {"rename_labels1"},
+                    "filter_labels": {"rename_labels1"},
+                    "rename_labels1": {"resample"},
+                    "resample": {"saveresult1"},
+                }
+            ),
+            [
+                ["loadco1", "filter_every_second", "filter_labels", "rename_labels1", "resample", "saveresult1"],
+                ["loadco1", "filter_labels", "filter_every_second", "rename_labels1", "resample", "saveresult1"],
+            ],
         ),
     ],
 )
-def test_execution_order(dependency_graph, dependents, expected_exection_order):
+def test_execution_order(dependency_graph, dependents, possible_exection_orders):
     execution_order = get_execution_order(dependency_graph, dependents)
-    assert execution_order == expected_exection_order
+    assert execution_order in possible_exection_orders

--- a/tests/tests_main/test_dependents.py
+++ b/tests/tests_main/test_dependents.py
@@ -1,0 +1,63 @@
+from collections import defaultdict
+
+import pytest
+
+from pg_to_evalscript.process_graph_utils import get_execution_order
+from tests.utils import get_process_graph_json
+
+
+def generate_default_dict_from_dict(d):
+    default_d = defaultdict(set)
+    for k, v in d.items():
+        default_d[k] = v
+    return default_d
+
+
+@pytest.mark.parametrize(
+    "dependency_graph,dependents,expected_exection_order",
+    [
+        (
+            generate_default_dict_from_dict(
+                {
+                    "loadco1": set(),
+                    "filter_every_second": {"loadco1"},
+                    "rename_labels1": {"filter_every_second"},
+                    "resample": {"loadco1", "rename_labels1"},
+                    "saveresult1": {"resample"},
+                }
+            ),
+            generate_default_dict_from_dict(
+                {
+                    "loadco1": {"resample", "filter_every_second"},
+                    "filter_every_second": {"rename_labels1"},
+                    "rename_labels1": {"resample"},
+                    "resample": {"saveresult1"},
+                }
+            ),
+            ["loadco1", "filter_every_second", "rename_labels1", "resample", "saveresult1"],
+        ),
+        (
+            generate_default_dict_from_dict(
+                {
+                    "loadco1": set(),
+                    "filter_every_second": {"loadco1"},
+                    "rename_labels1": {"filter_every_second"},
+                    "resample": {"loadco1", "rename_labels1"},
+                    "saveresult1": {"resample"},
+                }
+            ),
+            generate_default_dict_from_dict(
+                {
+                    "loadco1": {"filter_every_second", "resample"},
+                    "filter_every_second": {"rename_labels1"},
+                    "rename_labels1": {"resample"},
+                    "resample": {"saveresult1"},
+                }
+            ),
+            ["loadco1", "filter_every_second", "rename_labels1", "resample", "saveresult1"],
+        ),
+    ],
+)
+def test_execution_order(dependency_graph, dependents, expected_exection_order):
+    execution_order = get_execution_order(dependency_graph, dependents)
+    assert execution_order == expected_exection_order


### PR DESCRIPTION
Closes https://git.sinergise.com/team-6/openeo-platform/-/issues/176

The issue was that sometimes the order of the `node_id`s in `dependents` was different (I assume this has to do with `defaultdict`s not being ordered - not 100% sure where the difference arises). Anyway, if a node was not executable in that particular position (because it took results of some other node as input, but that node wasn't in execution order yet) we incorrectly broke out of the loop, so nothing was ever added to the execution order.