### PR TITLE
Support mosaicking: SIMPLE

### DIFF
--- a/src/pg_to_evalscript/javascript_datacube/DataCube.js
+++ b/src/pg_to_evalscript/javascript_datacube/DataCube.js
@@ -25,7 +25,7 @@ class DataCube {
         } else {
             this.data = data;
         }
-        if (scenes) {
+        if (Array.isArray(scenes)) {
             let dates = [];
             for (let scene of scenes) {
                 dates.push(typeof scene.date === 'string' ? scene.date : scene.date.toISOString());


### PR DESCRIPTION
If `mosaicking: "SIMPLE"` is set in the evalscript, `scenes` is an object and not labels should be set with the temporal dimension. Current implementation fails as it tries to iterate over an object.