### PR TITLE
Raise an error if constructing execution order is stuck

### DIFF
--- a/src/pg_to_evalscript/process_graph_utils.py
+++ b/src/pg_to_evalscript/process_graph_utils.py
@@ -61,7 +61,15 @@ def get_execution_order(dependencies, dependents):
     execution_order = [entry_point for entry_point in entry_points]
     remaining_nodes = set(dependencies.keys()).difference(execution_order)
 
+    prev_n_remaining_nodes = None
+
     while len(remaining_nodes) > 0:
+        if len(remaining_nodes) == prev_n_remaining_nodes:
+            raise RuntimeError(
+                f"Execution order of process graph nodes cannot be constructed. Make sure the process graph is valid. Nodes that cannot be placed in the execution order: {remaining_nodes}."
+            )
+        prev_n_remaining_nodes = len(remaining_nodes)
+
         for node in execution_order:
             for node_dependency in dependents[node]:
                 if node_dependency in execution_order:

--- a/tests/tests_main/test_dependents.py
+++ b/tests/tests_main/test_dependents.py
@@ -85,3 +85,37 @@ def generate_default_dict_from_dict(d):
 def test_execution_order(dependency_graph, dependents, possible_exection_orders):
     execution_order = get_execution_order(dependency_graph, dependents)
     assert execution_order in possible_exection_orders
+
+
+@pytest.mark.parametrize(
+    "dependency_graph,dependents,error",
+    [
+        (
+            generate_default_dict_from_dict(
+                {
+                    "loadco1": set(),
+                    "filterbbox1": {"loadco1"},
+                    "ndv1": {"filterbbox1"},
+                    "filterbbox2": {"ndvi1"},
+                    "saveres1": {"filterbbox2"},
+                }
+            ),
+            generate_default_dict_from_dict(
+                {
+                    "loadco1": {"filterbbox1"},
+                    "filterbbox1": {"ndv1"},
+                    "ndvi1": {"filterbbox2"},
+                    "filterbbox2": {"saveres1"},
+                }
+            ),
+            "Execution order of process graph nodes cannot be constructed.",
+        )
+    ],
+)
+def test_execution_order_error(dependency_graph, dependents, error):
+    try:
+        execution_order = get_execution_order(dependency_graph, dependents)
+    except Exception as e:
+        assert error in str(e)
+    else:
+        assert False, "Test expected an error, but no exception was raised."


### PR DESCRIPTION
Closes https://git.sinergise.com/team-6/openeo-platform/-/issues/177

Turns out there was a typo in the process graph that generated those dependencies/dependents (a node was `ndv1` but referred as `ndvi1` elsewhere.

If the process graph isn't valid, `get_execution_order` can get stuck in an infinite loop.  If we make no progress in a step, we raise an error.