### PR TITLE
Make sure get_dimensions_change in MergeCubesNode persists 'original_temporal' attribute

### DIFF
--- a/src/pg_to_evalscript/node.py
+++ b/src/pg_to_evalscript/node.py
@@ -237,6 +237,7 @@ function merge_cubes(arguments) {{
         So we set new sizes to the sums for *all* dimensions
         """
         dim_size_sums = defaultdict(int)
+        original_temporal_dimensions = []
 
         for dimensions_of_input in dimensions_of_inputs:
             for dim in dimensions_of_input:
@@ -245,9 +246,14 @@ function merge_cubes(arguments) {{
                 else:
                     dim_size_sums[dim["name"]] = None
 
+                if dim.get("original_temporal"):
+                    original_temporal_dimensions.append(dim["name"])
+
         output_dimensions = []
         for dim in dim_size_sums:
-            output_dimensions.append({"name": dim, "size": dim_size_sums[dim]})
+            output_dimensions.append(
+                {"name": dim, "size": dim_size_sums[dim], "original_temporal": dim in original_temporal_dimensions}
+            )
 
         return output_dimensions
 

--- a/tests/process_graphs/test_apply_filter_merge.json
+++ b/tests/process_graphs/test_apply_filter_merge.json
@@ -1,0 +1,89 @@
+{
+  "apply1": {
+    "arguments": {
+      "data": {
+        "from_node": "loadcollection1"
+      },
+      "process": {
+        "process_graph": {
+          "eq1": {
+            "arguments": {
+              "x": {
+                "from_parameter": "x"
+              },
+              "y": 34
+            },
+            "process_id": "eq",
+            "result": true
+          }
+        }
+      }
+    },
+    "process_id": "apply"
+  },
+  "filtertemporal1": {
+    "arguments": {
+      "data": {
+        "from_node": "apply1"
+      },
+      "extent": [
+        "2000-01-01",
+        "2000-01-02"
+      ]
+    },
+    "process_id": "filter_temporal"
+  },
+  "filtertemporal2": {
+    "arguments": {
+      "data": {
+        "from_node": "apply1"
+      },
+      "extent": [
+        "2018-01-01",
+        "2018-01-02"
+      ]
+    },
+    "process_id": "filter_temporal"
+  },
+  "loadcollection1": {
+    "arguments": {
+      "bands": [
+        "CLC"
+      ],
+      "id": "CORINE_LAND_COVER",
+      "spatial_extent": {
+        "east": 13.396453857421877,
+        "north": 47.19344533938292,
+        "south": 47.00647991252098,
+        "west": 12.284088134765625
+      },
+      "temporal_extent": [
+        "2000-01-01",
+        "2019-04-30"
+      ]
+    },
+    "process_id": "load_collection"
+  },
+  "mergecubes1": {
+    "arguments": {
+      "cube1": {
+        "from_node": "filtertemporal1"
+      },
+      "cube2": {
+        "from_node": "filtertemporal2"
+      }
+    },
+    "process_id": "merge_cubes"
+  },
+  "saveresult1": {
+    "arguments": {
+      "data": {
+        "from_node": "mergecubes1"
+      },
+      "format": "GTiff",
+      "options": {}
+    },
+    "process_id": "save_result",
+    "result": true
+  }
+}

--- a/tests/tests_main/test_determine_output_dimensions.py
+++ b/tests/tests_main/test_determine_output_dimensions.py
@@ -1,0 +1,28 @@
+import pytest
+
+from src.pg_to_evalscript import convert_from_process_graph
+
+from tests.utils import get_process_graph_json
+
+
+@pytest.mark.parametrize(
+    "process_graph,expected_output_dimensions",
+    [
+        (
+            "test_apply_filter_merge",
+            [{"name": "bands", "size": 2}, {"name": "t", "size": None, "original_temporal": True}],
+        )
+    ],
+)
+def test_determine_output_dimensions(process_graph, expected_output_dimensions):
+    pg = get_process_graph_json(process_graph)
+    evalscript = convert_from_process_graph(pg)[0]["evalscript"]
+    output_dimensions = evalscript.determine_output_dimensions()
+
+    assert len(output_dimensions) == len(expected_output_dimensions)
+    for i in range(len(expected_output_dimensions)):
+        assert output_dimensions[i]["name"] == expected_output_dimensions[i]["name"]
+        assert output_dimensions[i]["size"] == expected_output_dimensions[i]["size"]
+        assert output_dimensions[i].get("original_temporal", False) == expected_output_dimensions[i].get(
+            "original_temporal", False
+        )


### PR DESCRIPTION
Short overview of the problem:

1. For each node (process) in the process graph, we create a `Node` object
2. Each `Node` implements `get_dimensions_change` method, which says how this process changes the dimensions of the `DataCube`. By default it doesn't change the dimensions. Only "special" processes do, like `reduce_dimension`, `add_dimension`, `merge_cubes` etc
3. By default, when the `DataCube` is created in the evalscript, it has 2 dimensions: `bands`, which has the size of the number of input bands (which we know), and temporal dimension `t`, the size of which we do not know, thus the size is set to `None`. We use [`updateOutput` function of the evalscript](https://docs.sentinel-hub.com/api/latest/evalscript/v3/#updateoutput-function-optional) to determine its size in the runtime, when evalscript is actually being processed by Sentinel Hub and we know the number of `scenes`. Dimensional `t` is the `original_temporal` dimension, i.e. the temporal dimension we will get at runtime. If we created a temporal dimension with `add_dimension` process in the process graph, it wouldn't be `original_temporal`
4. By the way, processes like `filter_temporal` pose a problem, as we don't know how many scenes will be in that interval. So it makes sense to just keep the default (no change) `get_dimensions_change`, as it will at worst keep the same size as temporal dimension it is filtering. The only way we could determine it exactly is to make Catalog requests and then actually check on the driver how many `scenes` we'll have. However, we currently don't do that, which results in our returned data having too many bands, but those bands are empty.
5. The actual issue in our case was that `MergeCubesNode` dropped the `original_temporal` attribute inside `get_dimensions_change` 