### PR TITLE
save datacube metadata to evalscript's  userdata output

### DIFF
--- a/src/pg_to_evalscript/evalscript.py
+++ b/src/pg_to_evalscript/evalscript.py
@@ -74,16 +74,16 @@ let forUserData = {{}};
 function evaluatePixel(samples, scenes) {{
     {self.write_datacube_creation()}
     {(newline + tab).join([node.write_call() for node in self.nodes])}
-    
+
     forUserData = {{
-        outputDimensions: node_load1.dimensions,
+        outputDimensions: {self.write_output_variable()}.dimensions,
         outputDatacubeMetadata: {{
-            shape: node_load1.data.shape, 
-            stride: node_load1.data.stride, 
-            offset: node_load1.data.offset
+            shape: {self.write_output_variable()}.data.shape, 
+            stride: {self.write_output_variable()}.data.stride, 
+            offset: {self.write_output_variable()}.data.offset
         }}
     }}
-    
+
     const finalOutput = {self.write_output_variable()}{".encodeData()" if self.encode_result else '.flattenToArray()'}
     return Array.isArray(finalOutput) ? finalOutput : [finalOutput];
 }}

--- a/src/pg_to_evalscript/evalscript.py
+++ b/src/pg_to_evalscript/evalscript.py
@@ -66,11 +66,30 @@ function setup() {{
 {self.write_ndarray_definition()}
 {self.write_datacube_definition()}
 {newline.join([node.write_function() for node in self.nodes])}
+
+// this var gets metadata about the dimensions of the datacube for postprocessing
+// it is saved as userdata.json 
+let forUserData = {{}};
+
 function evaluatePixel(samples, scenes) {{
     {self.write_datacube_creation()}
     {(newline + tab).join([node.write_call() for node in self.nodes])}
+    
+    forUserData = {{
+        outputDimensions: node_load1.dimensions,
+        outputDatacubeMetadata: {{
+            shape: node_load1.data.shape, 
+            stride: node_load1.data.stride, 
+            offset: node_load1.data.offset
+        }}
+    }}
+    
     const finalOutput = {self.write_output_variable()}{".encodeData()" if self.encode_result else '.flattenToArray()'}
     return Array.isArray(finalOutput) ? finalOutput : [finalOutput];
+}}
+
+function updateOutputMetadata(scenes, inputMetadata, outputMetadata) {{
+  outputMetadata.userData = forUserData;
 }}
 """
 


### PR DESCRIPTION
adds dimensions to userdata.json so that post-processing can be done