### PR TITLE
Fix/list supported processes duplication

### DIFF
--- a/src/pg_to_evalscript/utils.py
+++ b/src/pg_to_evalscript/utils.py
@@ -8,4 +8,5 @@ def list_supported_processes():
     supported_processes_with_files = [
         process_definition_file.replace(".js", "") for process_definition_file in process_definition_files
     ]
-    return [*implicitly_supported_processes, *supported_processes_with_files]
+    unique_supported_processes = list(set([*implicitly_supported_processes, *supported_processes_with_files]))
+    return unique_supported_processes

--- a/src/pg_to_evalscript/utils.py
+++ b/src/pg_to_evalscript/utils.py
@@ -3,7 +3,7 @@ import pkg_resources
 
 def list_supported_processes():
     process_definitions_directory = "javascript_processes"
-    implicitly_supported_processes = ["load_collection", "save_result", "reduce_dimension", "apply"]
+    implicitly_supported_processes = ["load_collection", "save_result"]
     process_definition_files = pkg_resources.resource_listdir("pg_to_evalscript", f"{process_definitions_directory}")
     supported_processes_with_files = [
         process_definition_file.replace(".js", "") for process_definition_file in process_definition_files

--- a/src/pg_to_evalscript/utils.py
+++ b/src/pg_to_evalscript/utils.py
@@ -1,9 +1,9 @@
 import pkg_resources
 
+implicitly_supported_processes = ["load_collection", "save_result"]
 
 def list_supported_processes():
     process_definitions_directory = "javascript_processes"
-    implicitly_supported_processes = ["load_collection", "save_result"]
     process_definition_files = pkg_resources.resource_listdir("pg_to_evalscript", f"{process_definitions_directory}")
     supported_processes_with_files = [
         process_definition_file.replace(".js", "") for process_definition_file in process_definition_files

--- a/tests/integration_tests/test_integration.py
+++ b/tests/integration_tests/test_integration.py
@@ -261,10 +261,10 @@ def test_process_graphs_with_scenes(pg_name, example_input, scenes, expected_out
 
 
 def test_list_supported_processes():
-    known_supported_processes = [
+    known_supported_processes = list(set([
         *implicitly_supported_processes,
         *get_defined_processes_from_files(),
-    ]
+    ]))
     supported_processes = list_supported_processes()
     assert len(known_supported_processes) == len(supported_processes)
     assert set(known_supported_processes) == set(supported_processes)

--- a/tests/integration_tests/test_integration.py
+++ b/tests/integration_tests/test_integration.py
@@ -2,6 +2,7 @@ import json
 
 import pytest
 from pg_to_evalscript import convert_from_process_graph, list_supported_processes
+from pg_to_evalscript.utils import implicitly_supported_processes
 
 from tests.utils import (
     get_process_graph_json,
@@ -261,10 +262,7 @@ def test_process_graphs_with_scenes(pg_name, example_input, scenes, expected_out
 
 def test_list_supported_processes():
     known_supported_processes = [
-        "load_collection",
-        "save_result",
-        "reduce_dimension",
-        "apply",
+        *implicitly_supported_processes,
         *get_defined_processes_from_files(),
     ]
     supported_processes = list_supported_processes()


### PR DESCRIPTION
- remove `reduce_dimension`, `apply` from the `implicitly_supported_processes` in `list_supported_processes()` because `js` files exist for them
- return only unique values in `list_supported_processes()` 
- expose `implicitly_supported_processes` variable so it can be used in tests to avoid duplicating code


fixes https://git.sinergise.com/team-6/openeo-platform/-/issues/219
connected to https://github.com/Open-EO/openeo-sentinelhub-python-driver/pull/48