### PR TITLE
Draft: measure execution time

### DIFF
--- a/src/pg_to_evalscript/evalscript.py
+++ b/src/pg_to_evalscript/evalscript.py
@@ -53,6 +53,9 @@ class Evalscript:
         tab = "\t"
         return f"""
 //VERSION=3
+
+const executionTimes = [];
+
 function setup() {{
   return {{
     input: [{",".join([f"'{band}'" for band in self.input_bands])}],
@@ -85,6 +88,8 @@ function evaluatePixel(samples, scenes) {{
     }}
 
     const finalOutput = {self.write_output_variable()}{".encodeData()" if self.encode_result else '.flattenToArray()'}
+    
+    throw new Error(JSON.stringify(executionTimes));
     return Array.isArray(finalOutput) ? finalOutput : [finalOutput];
 }}
 

--- a/src/pg_to_evalscript/javascript_common/common.js
+++ b/src/pg_to_evalscript/javascript_common/common.js
@@ -5,6 +5,8 @@ const DATE_TIME_TYPES = {
 }
 
 function parse_rfc3339(dateTime, default_h = 0, default_m = 0, default_s = 0) {
+  const startTime = Date.now()
+
   const regexDateTime =
     "^([0-9]{4})-([0-9]{2})-([0-9]{2})([Tt]([0-9]{2}):([0-9]{2}):([0-9]{2})(\.[0-9]+)?)([Zz]|([+-])([0-9]{2}):([0-9]{2}))";
   const regexDate = "^([0-9]{4})-([0-9]{2})-([0-9]{2})$";
@@ -14,6 +16,10 @@ function parse_rfc3339(dateTime, default_h = 0, default_m = 0, default_s = 0) {
     const matchDate = dateTime.match(regexDate);
 
     if (matchDateTime || matchDate) {
+      const endTime = Date.now()
+
+      executionTimes.push({ fun: "parse_rfc3339", params: {dateTime}, success: true, time: endTime - startTime });
+
       return {
         type: matchDate ? DATE_TIME_TYPES.date : DATE_TIME_TYPES.date_time,
         value: new Date(dateTime).toISOString(),
@@ -21,6 +27,8 @@ function parse_rfc3339(dateTime, default_h = 0, default_m = 0, default_s = 0) {
     }
   } catch (err) {}
 
+  const endTime = Date.now()
+  executionTimes.push({ fun: "parse_rfc3339", params: { dateTime }, success: false, time: endTime - startTime });
   return null;
 }
 
@@ -125,6 +133,8 @@ const formatLabelByPeriod = (period, label) => {
 };
 
 const generateDatesInRangeByPeriod = (minDate, maxDate, period) => {
+  const startTime = Date.now();
+  
   const addPeriodToDate = (currentDate, period) => {
     let newDate = new Date(currentDate);
     switch (period) {
@@ -178,6 +188,9 @@ const generateDatesInRangeByPeriod = (minDate, maxDate, period) => {
     dates.push(currentDate);
     currentDate = addPeriodToDate(currentDate, period);
   }
+
+  const endTime = Date.now();
+  executionTimes.push({ fun: "generateDatesInRangeByPeriod", params: { minDate, maxDate, period }, success: true, time: endTime - startTime });
 
   return dates;
 };

--- a/src/pg_to_evalscript/javascript_datacube/ndarray.js
+++ b/src/pg_to_evalscript/javascript_datacube/ndarray.js
@@ -21,10 +21,13 @@
 // THE SOFTWARE.
 
 function iota(n) {
+  const startTime = Date.now();
   var result = new Array(n)
   for(var i=0; i<n; ++i) {
     result[i] = i
   }
+  const endTime = Date.now();
+  executionTimes.push({ fun: "iota", params: { n }, success: true, time: endTime - startTime });
   return result
 }
 function isBuffer (obj) {
@@ -39,6 +42,7 @@ function compare1st(a, b) {
 }
 
 function order() {
+  const startTime = Date.now();
   var stride = this.stride
   var terms = new Array(stride.length)
   var i
@@ -50,10 +54,14 @@ function order() {
   for(i=0; i<result.length; ++i) {
     result[i] = terms[i][1]
   }
+  const endTime = Date.now();
+  executionTimes.push({ fun: "order", params: { }, success: true, time: endTime - startTime });
   return result
 }
 
 function compileConstructor(dtype, dimension) {
+  const startTime = Date.now();
+  
   var className = ["View", dimension, "d", dtype].join("")
   if(dimension < 0) {
     className = "View_Nil" + dtype
@@ -76,6 +84,8 @@ proto.get=proto.set=function(){};\
 proto.pick=function(){return null};\
 return function construct_"+className+"(a){return new "+className+"(a);}"
     var procedure = new Function(code)
+    const endTime = Date.now();
+    executionTimes.push({ fun: "compileConstructor", params: { dtype, dimension }, success: true, time: endTime - startTime });
     return procedure()
   } else if(dimension === 0) {
     //Special case for 0d arrays
@@ -109,6 +119,8 @@ return "+(useGetters ? "this.data.set(this.offset,v)" : "this.data[this.offset]=
 };\
 return function construct_"+className+"(a,b,c,d){return new "+className+"(a,d)}"
     var procedure = new Function("TrivialArray", code)
+    const endTime = Date.now();
+    executionTimes.push({ fun: "compileConstructor", params: { dtype, dimension }, success: true, time: endTime - startTime });
     return procedure(CACHED_CONSTRUCTORS[dtype][0])
   }
 
@@ -280,6 +292,8 @@ b"+i+"*=d\
 
   //Compile procedure
   var procedure = new Function("CTOR_LIST", "ORDER", code.join("\n"))
+  const endTime = Date.now();
+  executionTimes.push({ fun: "compileConstructor", params: { dtype, dimension }, success: true, time: endTime - startTime });
   return procedure(CACHED_CONSTRUCTORS[dtype], order)
 }
 
@@ -343,6 +357,8 @@ var CACHED_CONSTRUCTORS = {
 });
 
 function ndarray(data, shape, stride, offset) {
+  const startTime = Date.now();
+  
   if(data === undefined) {
     var ctor = CACHED_CONSTRUCTORS.array[0]
     return ctor([])
@@ -374,47 +390,66 @@ function ndarray(data, shape, stride, offset) {
     ctor_list.push(compileConstructor(dtype, ctor_list.length-1))
   }
   var ctor = ctor_list[d+1]
+  const endTime = Date.now();
+  executionTimes.push({ fun: "ndarray", params: { shape, stride, offset }, success: true, time: endTime - startTime });
   return ctor(data, shape, stride, offset)
 }
 
 // ------------------------------------------------------------------------------------------------------
 
 function convert_to_1d_array(ndarray) {
+  const startTime = Date.now();
     const arr = []
     for (let i = 0; i < ndarray.shape[0]; i++) {
         arr.push(ndarray.get(i))
     }
+  const endTime = Date.now();
+  executionTimes.push({ fun: "convert_to_1d_array", params: { ndarrayLength: ndarray.length }, success: true, time: endTime - startTime });
     return arr
 }
 
 function extractValues(obj) {
+  const startTime = Date.now();
     const values = [];
     for (var key in obj) {
         values.push(obj[key]);
-    }
+  }
+  const endTime = Date.now();
+  executionTimes.push({ fun: "extractValues", params: { obj }, success: true, time: endTime - startTime });
     return values;
 }
 
 function fill(arr, val) {
+  const startTime = Date.now();
     const size = arr.length
     for (let i = 0; i < size; i++) {
         arr[i] = val
-    }
+  }
+  const endTime = Date.now();
+  executionTimes.push({ fun: "fill", params: { arrLength: arr.length, val }, success: true, time: endTime - startTime });
     return arr
 }
 
 function isNotSubarray(ndarray, shape) {
+  const startTime = Date.now();
     let length = 1;
     for (let i = 0; i < shape.length; i++) {
         length *= shape[i]
     }
+
+  const endTime = Date.now();
+  executionTimes.push({ fun: "isNotSubarray", params: { ndarrayLength: ndarray.length, shape }, success: true, time: endTime - startTime });
     return length === ndarray.data.length
 }
 
 function flattenToNativeArray(ndarray, useAllNdarrayProperties = false) {
+  const startTime = Date.now();
     const shape = ndarray.shape
 
     if (!useAllNdarrayProperties && isNotSubarray(ndarray, shape)) {
+
+      const endTime = Date.now();
+      executionTimes.push({ fun: "flattenToNativeArray", params: { ndarrayLength: ndarray.length, useAllNdarrayProperties }, success: true, time: endTime - startTime });
       return ndarray.data.slice();
     }
   
@@ -433,6 +468,9 @@ function flattenToNativeArray(ndarray, useAllNdarrayProperties = false) {
         }
         arr.push(ndarray.get.apply(ndarray, coord))
     }
+
+  const endTime = Date.now();
+  executionTimes.push({ fun: "flattenToNativeArray", params: { ndarrayLength: ndarray.length, useAllNdarrayProperties }, success: true, time: endTime - startTime });
     return arr
 }
 
@@ -455,11 +493,16 @@ function flattenToNativeArray(ndarray, useAllNdarrayProperties = false) {
 */
 
 function broadcastNdarray(inputArray, targetShape) {
+  const startTime = Date.now();
+
   
   const targetNumOfDimensions = targetShape.length;
   const inputArrayNumOfDimensions = inputArray.shape.length;
 
   if (targetNumOfDimensions < inputArrayNumOfDimensions) {
+
+    const endTime = Date.now();
+    executionTimes.push({ fun: "broadcastNdarray", params: { inputArrayLength: inputArray.shape, targetShape }, success: false, time: endTime - startTime });
     throw new Error('invalid argument. Cannot broadcast an array to a shape having fewer dimensions. Arrays can only be broadcasted to shapes having the same or more dimensions.');
   }
 
@@ -482,6 +525,9 @@ function broadcastNdarray(inputArray, targetShape) {
     }
     
     if (currentDim !== 0 && currentDim < inputArrayDim) {
+
+      const endTime = Date.now();
+      executionTimes.push({ fun: "broadcastNdarray", params: { inputArrayLength: inputArray.shape, targetShape }, success: false, time: endTime - startTime });
       throw new Error(format('invalid argument. Input array cannot be broadcast to the specified shape, as the specified shape has a dimension whose size is less than the size of the corresponding dimension in the input array. Array shape: (%s). Desired shape: (%s). Dimension: %u.', inputArray.shape.slice().join(', '), targetShape.slice().join(', '), i));
     }
     if (inputArrayDim === currentDim) {
@@ -490,10 +536,16 @@ function broadcastNdarray(inputArray, targetShape) {
       // In order to broadcast dimensions, we set the stride for that dimension to zero...
       generatedStrides[i] = 0;
     } else {
+
+      const endTime = Date.now();
+      executionTimes.push({ fun: "broadcastNdarray", params: { inputArrayLength: inputArray.shape, targetShape }, success: false, time: endTime - startTime });
       // At this point, we know that `dim > d` and that `d` does not equal `1` (e.g., `dim=3` and `d=2`); in which case, the shapes are considered incompatible (even for desired shapes which are multiples of array dimensions, as might be desired when "tiling" an array; e.g., `dim=4` and `d=2`)...
       throw new Error(format('invalid argument. Input array and the specified shape are broadcast incompatible. Array shape: (%s). Desired shape: (%s). Dimension: %u.', inputArray.shape.slice().join(', '), targetShape.slice().join(', '), i));
     }
   }
   const newArr = ndarray(inputArray.data, targetShape.slice(), generatedStrides, inputArray.offset);
+
+  const endTime = Date.now();
+  executionTimes.push({ fun: "broadcastNdarray", params: { inputArrayLength: inputArray.shape, targetShape }, success: true, time: endTime - startTime });
   return newArr;
 }

--- a/src/pg_to_evalscript/javascript_processes/absolute.js
+++ b/src/pg_to_evalscript/javascript_processes/absolute.js
@@ -1,4 +1,5 @@
 function absolute(arguments) {
+  const startTime = Date.now();
   const { x } = arguments;
 
   validateParameter({
@@ -13,5 +14,7 @@ function absolute(arguments) {
     return null;
   }
 
+  const endTime = Date.now();
+  executionTimes.push({ fun: "absolute.js", params: { x }, success: true, time: endTime - startTime });
   return Math.abs(x);
 }

--- a/src/pg_to_evalscript/javascript_processes/add.js
+++ b/src/pg_to_evalscript/javascript_processes/add.js
@@ -1,4 +1,5 @@
 function add(arguments) {
+  const startTime = Date.now();
   const { x, y } = arguments;
 
   validateParameter({
@@ -21,5 +22,7 @@ function add(arguments) {
     return null;
   }
 
+  const endTime = Date.now();
+  executionTimes.push({ fun: "add.js", params: {x,y}, success: true, time: endTime - startTime });
   return x + y;
 }

--- a/src/pg_to_evalscript/javascript_processes/add_dimension.js
+++ b/src/pg_to_evalscript/javascript_processes/add_dimension.js
@@ -1,4 +1,5 @@
 function add_dimension(arguments) {
+  const startTime = Date.now();
   const { data, name, label, type = "other" } = arguments;
 
   validateParameter({
@@ -37,5 +38,7 @@ function add_dimension(arguments) {
 
   let newData = data.clone();
   newData.addDimension(name, label, type);
+  const endTime = Date.now();
+  executionTimes.push({ fun: "add_dimension.js", params: {name, label, type}, success: true, time: endTime - startTime });
   return newData;
 }

--- a/src/pg_to_evalscript/javascript_processes/aggregate_temporal.js
+++ b/src/pg_to_evalscript/javascript_processes/aggregate_temporal.js
@@ -1,4 +1,5 @@
 function aggregate_temporal(arguments) {
+  const startTime = Date.now();
   const { data, intervals, reducer, labels = [], dimension = null, context = null } = arguments;
 
   validateParameter({
@@ -54,5 +55,7 @@ function aggregate_temporal(arguments) {
 
   const newData = data.clone();
   newData.aggregateTemporal(intervals, reducer, labels, dimension, context);
+  const endTime = Date.now();
+  executionTimes.push({ fun: "aggregate_temporal.js", params: {intervals, dimension, labels}, success: true, time: endTime - startTime });
   return newData;
 }

--- a/src/pg_to_evalscript/javascript_processes/aggregate_temporal_period.js
+++ b/src/pg_to_evalscript/javascript_processes/aggregate_temporal_period.js
@@ -1,4 +1,5 @@
 function aggregate_temporal_period(arguments) {
+  const startTime = Date.now();
   const { data, period, reducer, dimension = null, context = null } = arguments;
 
   validateParameter({
@@ -41,5 +42,7 @@ function aggregate_temporal_period(arguments) {
 
   const newData = data.clone();
   newData.aggregateTemporalPeriod(period, reducer, dimension, context);
+  const endTime = Date.now();
+  executionTimes.push({ fun: "aggregate_temporal_period.js", params: {period, dimension}, success: true, time: endTime - startTime });
   return newData;
 }

--- a/src/pg_to_evalscript/javascript_processes/all.js
+++ b/src/pg_to_evalscript/javascript_processes/all.js
@@ -1,4 +1,5 @@
 function all(arguments) {
+  const startTime = Date.now();
   const { data, ignore_nodata = true } = arguments;
 
   validateParameter({
@@ -30,11 +31,14 @@ function all(arguments) {
 
       returnVal = true;
     }
-
+    const endTime = Date.now();
+    executionTimes.push({ fun: "all.js", params: {}, success: true, time: endTime - startTime });
     return returnVal;
   }
 
   if (data.length === 1) {
+    const endTime = Date.now();
+    executionTimes.push({ fun: "all.js", params: {}, success: true, time: endTime - startTime });
     return data[0];
   }
 
@@ -54,11 +58,17 @@ function all(arguments) {
     });
 
     if (x === false || y === false) {
+      const endTime = Date.now();
+      executionTimes.push({ fun: "all.js", params: {}, success: true, time: endTime - startTime });
       return false;
     }
     if (x === true && y === true) {
+      const endTime = Date.now();
+      executionTimes.push({ fun: "all.js", params: {}, success: true, time: endTime - startTime });
       return true;
     }
+    const endTime = Date.now();
+    executionTimes.push({ fun: "all.js", params: {}, success: true, time: endTime - startTime });
     return null;
   }, null);
 }

--- a/src/pg_to_evalscript/javascript_processes/and.js
+++ b/src/pg_to_evalscript/javascript_processes/and.js
@@ -1,4 +1,5 @@
 function and(arguments) {
+  const startTime = Date.now();
   const { x, y } = arguments;
 
   validateParameter({
@@ -18,12 +19,18 @@ function and(arguments) {
   });
 
   if (x === false || y === false) {
+    const endTime = Date.now();
+    executionTimes.push({ fun: "and.js", params: {}, success: true, time: endTime - startTime });
     return false;
   }
 
   if (x && y) {
+    const endTime = Date.now();
+    executionTimes.push({ fun: "and.js", params: {}, success: true, time: endTime - startTime });
     return true;
   }
 
+  const endTime = Date.now();
+  executionTimes.push({ fun: "and.js", params: {}, success: true, time: endTime - startTime });
   return null;
 }

--- a/src/pg_to_evalscript/javascript_processes/any.js
+++ b/src/pg_to_evalscript/javascript_processes/any.js
@@ -1,4 +1,5 @@
 function any(arguments) {
+  const startTime = Date.now();
   const { data, ignore_nodata = true } = arguments;
 
   validateParameter({
@@ -31,6 +32,8 @@ function any(arguments) {
       returnVal = false;
     }
 
+    const endTime = Date.now();
+    executionTimes.push({ fun: "any.js", params: {}, success: true, time: endTime - startTime });
     return returnVal;
   }
 
@@ -54,11 +57,17 @@ function any(arguments) {
     });
 
     if (x === true || y === true) {
+      const endTime = Date.now();
+      executionTimes.push({ fun: "any.js", params: {}, success: true, time: endTime - startTime });
       return true;
     }
     if (x === false && y === false) {
+      const endTime = Date.now();
+      executionTimes.push({ fun: "any.js", params: {}, success: true, time: endTime - startTime });
       return false;
     }
+    const endTime = Date.now();
+    executionTimes.push({ fun: "any.js", params: {}, success: true, time: endTime - startTime });
     return null;
   }, null);
 }

--- a/src/pg_to_evalscript/javascript_processes/apply.js
+++ b/src/pg_to_evalscript/javascript_processes/apply.js
@@ -1,4 +1,5 @@
 function apply(arguments) {
+  const startTime = Date.now();
   const { data, process, context = null } = arguments;
 
   validateParameter({
@@ -19,5 +20,7 @@ function apply(arguments) {
 
   const newData = data.clone();
   newData.apply(process, context);
+  const endTime = Date.now();
+  executionTimes.push({ fun: "apply.js", params: {}, success: true, time: endTime - startTime });
   return newData;
 }

--- a/src/pg_to_evalscript/javascript_processes/apply_dimension.js
+++ b/src/pg_to_evalscript/javascript_processes/apply_dimension.js
@@ -1,4 +1,5 @@
 function apply_dimension(arguments) {
+  const startTime = Date.now();
   const { data, process, dimension, target_dimension = null, context = null } = arguments;
 
   validateParameter({
@@ -45,5 +46,7 @@ function apply_dimension(arguments) {
 
   const newData = data.clone();
   newData.applyDimension(process, dimension, target_dimension, context);
+  const endTime = Date.now();
+  executionTimes.push({ fun: "apply_dimension.js", params: {}, success: true, time: endTime - startTime });
   return newData;
 }

--- a/src/pg_to_evalscript/javascript_processes/array_apply.js
+++ b/src/pg_to_evalscript/javascript_processes/array_apply.js
@@ -1,4 +1,5 @@
 function array_apply(arguments) {
+  const startTime = Date.now();
   const { data, process, context = null } = arguments;
 
   validateParameter({
@@ -29,5 +30,7 @@ function array_apply(arguments) {
     });
   }
 
+  const endTime = Date.now();
+  executionTimes.push({ fun: "array_apply.js", params: {}, success: true, time: endTime - startTime });
   return newData;
 }

--- a/src/pg_to_evalscript/javascript_processes/array_filter.js
+++ b/src/pg_to_evalscript/javascript_processes/array_filter.js
@@ -1,4 +1,5 @@
 function array_filter(arguments) {
+  const startTime = Date.now();
   const { data, condition: cond, context } = arguments;
 
   validateParameter({
@@ -24,5 +25,7 @@ function array_filter(arguments) {
     }
   }
 
+  const endTime = Date.now();
+  executionTimes.push({ fun: "array_filter.js", params: {}, success: true, time: endTime - startTime });
   return filteredData;
 }

--- a/src/pg_to_evalscript/javascript_processes/array_interpolate_linear.js
+++ b/src/pg_to_evalscript/javascript_processes/array_interpolate_linear.js
@@ -1,4 +1,5 @@
 function array_interpolate_linear(arguments) {
+  const startTime = Date.now();
   const { data } = arguments;
 
   validateParameter({
@@ -47,5 +48,7 @@ function array_interpolate_linear(arguments) {
     nullIndices = [];
   }
 
+  const endTime = Date.now();
+  executionTimes.push({ fun: "array_interpolate_linear.js", params: {}, success: true, time: endTime - startTime });
   return newData;
 }

--- a/src/pg_to_evalscript/javascript_processes/between.js
+++ b/src/pg_to_evalscript/javascript_processes/between.js
@@ -1,4 +1,5 @@
 function between(arguments) {
+  const startTime = Date.now();
   const isBetween = (x, min, max, exclude_max) => {
     let result = x >= min && x <= max;
     if (exclude_max) {
@@ -57,6 +58,8 @@ function between(arguments) {
       excludeMax = true;
     }
 
+    const endTime = Date.now();
+    executionTimes.push({ fun: "between.js", params: {}, success: true, time: endTime - startTime });
     return isBetween(
       xAsISODateString.value,
       minAsISODateString.value,
@@ -64,6 +67,8 @@ function between(arguments) {
       excludeMax
     );
   } else {
+    const endTime = Date.now();
+    executionTimes.push({ fun: "between.js", params: {}, success: true, time: endTime - startTime });
     return isBetween(x, min, max, exclude_max);
   }
 }

--- a/src/pg_to_evalscript/javascript_processes/count.js
+++ b/src/pg_to_evalscript/javascript_processes/count.js
@@ -1,4 +1,5 @@
 function count(arguments) {
+  const startTime = Date.now();
   const { data, condition: cond = null } = arguments;
 
   validateParameter({
@@ -41,5 +42,7 @@ function count(arguments) {
     }
   }
 
+  const endTime = Date.now();
+  executionTimes.push({ fun: "count.js", params: {}, success: true, time: endTime - startTime });
   return count;
 }

--- a/src/pg_to_evalscript/javascript_processes/drop_dimension.js
+++ b/src/pg_to_evalscript/javascript_processes/drop_dimension.js
@@ -1,4 +1,5 @@
 function drop_dimension(arguments) {
+  const startTime = Date.now();
   const { data, name } = arguments;
 
   validateParameter({
@@ -38,5 +39,7 @@ function drop_dimension(arguments) {
 
   let newData = data.clone();
   newData.removeDimension(name);
+  const endTime = Date.now();
+  executionTimes.push({ fun: "drop_dimension.js", params: {}, success: true, time: endTime - startTime });
   return newData;
 }

--- a/src/pg_to_evalscript/javascript_processes/extrema.js
+++ b/src/pg_to_evalscript/javascript_processes/extrema.js
@@ -1,4 +1,5 @@
 function extrema(arguments) {
+  const startTime = Date.now();
   const { data, ignore_nodata = true } = arguments;
 
   validateParameter({
@@ -55,5 +56,7 @@ function extrema(arguments) {
     }
   }
 
+  const endTime = Date.now();
+  executionTimes.push({ fun: "extrema.js", params: {}, success: true, time: endTime - startTime });
   return [minVal, maxVal];
 }

--- a/src/pg_to_evalscript/javascript_processes/filter_bands.js
+++ b/src/pg_to_evalscript/javascript_processes/filter_bands.js
@@ -1,4 +1,5 @@
 function filter_bands(arguments) {
+  const startTime = Date.now();
   const { data, bands = [], wavelengths = [] } = arguments;
 
   if (data === undefined) {
@@ -29,5 +30,7 @@ function filter_bands(arguments) {
 
   const newData = data.clone();
   newData.filterBands(bands);
+  const endTime = Date.now();
+  executionTimes.push({ fun: "filter_bands.js", params: {}, success: true, time: endTime - startTime });
   return newData;
 }

--- a/src/pg_to_evalscript/javascript_processes/filter_temporal.js
+++ b/src/pg_to_evalscript/javascript_processes/filter_temporal.js
@@ -1,4 +1,5 @@
 function filter_temporal(arguments) {
+  const startTime = Date.now();
   const { data, extent, dimension } = arguments;
 
   validateParameter({
@@ -29,5 +30,7 @@ function filter_temporal(arguments) {
 
   const newData = data.clone();
   newData.filterTemporal(extent, dimension);
+  const endTime = Date.now();
+  executionTimes.push({ fun: "filter_temporal.js", params: {}, success: true, time: endTime - startTime });
   return newData;
 }

--- a/src/pg_to_evalscript/javascript_processes/mask.js
+++ b/src/pg_to_evalscript/javascript_processes/mask.js
@@ -1,4 +1,5 @@
 function mask(arguments) {
+  const startTime = Date.now();
   const { data, mask, replacement = null } = arguments;
 
   validateParameter({
@@ -80,5 +81,7 @@ function mask(arguments) {
   }
   
   newData.data.data = newDataFlat;
+  const endTime = Date.now();
+  executionTimes.push({ fun: "mask.js", params: {}, success: true, time: endTime - startTime });
   return newData;
 }

--- a/src/pg_to_evalscript/javascript_processes/max.js
+++ b/src/pg_to_evalscript/javascript_processes/max.js
@@ -1,4 +1,5 @@
 function max(arguments) {
+const startTime = Date.now();
   const { data, ignore_nodata = true } = arguments;
 
   validateParameter({
@@ -45,5 +46,13 @@ function max(arguments) {
     }
   }
 
+const endTime = Date.now();
+executionTimes.push({ fun: "max.js", params: {}, success: true, time: endTime - startTime });
   return maxVal;
 }
+
+
+// x = [1, 2, 10, null, 39, 23, null, 4, 4, null, 6, 2, 1]
+// x.sort((a, b) => b - a) // add value validation
+// x[0] : MAX
+// x[x.length - 1] : IF NULL -> no_data exists in data

--- a/src/pg_to_evalscript/javascript_processes/mean.js
+++ b/src/pg_to_evalscript/javascript_processes/mean.js
@@ -1,4 +1,5 @@
 function mean(arguments) {
+const startTime = Date.now();
   const { data, ignore_nodata = true } = arguments;
 
   validateParameter({
@@ -44,5 +45,7 @@ function mean(arguments) {
     return null;
   }
 
+const endTime = Date.now();
+executionTimes.push({ fun: "mean.js", params: {}, success: true, time: endTime - startTime });
   return sum / el_num;
 }

--- a/src/pg_to_evalscript/javascript_processes/median.js
+++ b/src/pg_to_evalscript/javascript_processes/median.js
@@ -1,4 +1,5 @@
 function median(arguments) {
+const startTime = Date.now();
   const { data, ignore_nodata = true } = arguments;
 
   validateParameter({
@@ -48,5 +49,7 @@ function median(arguments) {
     return (newData[bottomHalfIdx - 1] + newData[bottomHalfIdx]) / 2;
   }
 
+const endTime = Date.now();
+executionTimes.push({ fun: "median.js", params: {}, success: true, time: endTime - startTime });
   return newData[bottomHalfIdx];
 }

--- a/src/pg_to_evalscript/javascript_processes/merge_cubes.js
+++ b/src/pg_to_evalscript/javascript_processes/merge_cubes.js
@@ -1,4 +1,5 @@
 function merge_cubes(arguments) {
+const startTime = Date.now();
   let { cube1, cube2, overlap_resolver = null, context = null } = arguments;
 
   if (cube1 === undefined) {
@@ -18,5 +19,7 @@ function merge_cubes(arguments) {
   cube1.merge(cube2, overlap_resolver)
 
 
+const endTime = Date.now();
+executionTimes.push({ fun: "merge_cubes.js", params: {}, success: true, time: endTime - startTime });
   return cube1;
 }

--- a/src/pg_to_evalscript/javascript_processes/min.js
+++ b/src/pg_to_evalscript/javascript_processes/min.js
@@ -1,4 +1,5 @@
 function min(arguments) {
+const startTime = Date.now();
   const { data, ignore_nodata = true } = arguments;
 
   validateParameter({
@@ -45,5 +46,9 @@ function min(arguments) {
     }
   }
 
+const endTime = Date.now();
+executionTimes.push({ fun: "min.js", params: {}, success: true, time: endTime - startTime });
   return minVal;
 }
+
+// similar to max.js

--- a/src/pg_to_evalscript/javascript_processes/ndvi.js
+++ b/src/pg_to_evalscript/javascript_processes/ndvi.js
@@ -1,4 +1,5 @@
 function ndvi(arguments) {
+  const startTime = Date.now();
   const { data, nir = "nir", red = "red", target_band = null } = arguments;
 
   validateParameter({
@@ -95,5 +96,7 @@ function ndvi(arguments) {
     ({ data }) => (data[nirIdx] - data[redIdx]) / (data[nirIdx] + data[redIdx]),
     bandsDim.name
   );
+  const endTime = Date.now();
+  executionTimes.push({ fun: "ndvi.js", params: {}, success: true, time: endTime - startTime });
   return clonedData;
 }

--- a/src/pg_to_evalscript/javascript_processes/order.js
+++ b/src/pg_to_evalscript/javascript_processes/order.js
@@ -1,5 +1,6 @@
 function order(arguments) {
-  const { data, asc = true, nodata = null} = arguments;
+  const startTime = Date.now();
+  const { data, asc = true, nodata = null } = arguments;
 
   validateParameter({
     processName: "order",
@@ -58,5 +59,7 @@ function order(arguments) {
     }
   }
 
+  const endTime = Date.now();
+  executionTimes.push({ fun: "order.js", params: {}, success: true, time: endTime - startTime });
   return sortedIndexes;
 }

--- a/src/pg_to_evalscript/javascript_processes/product.js
+++ b/src/pg_to_evalscript/javascript_processes/product.js
@@ -1,4 +1,5 @@
 function product(arguments) {
+  const startTime = Date.now();
   const { data, ignore_nodata = true } = arguments;
 
   validateParameter({
@@ -42,5 +43,7 @@ function product(arguments) {
     product = null;
   }
 
+  const endTime = Date.now();
+  executionTimes.push({ fun: "product.js", params: {}, success: true, time: endTime - startTime });
   return product;
 }

--- a/src/pg_to_evalscript/javascript_processes/quantiles.js
+++ b/src/pg_to_evalscript/javascript_processes/quantiles.js
@@ -1,4 +1,5 @@
 function quantiles(arguments) {
+  const startTime = Date.now();
   const { data, probabilities, q, ignore_nodata = true } = arguments;
 
   validateParameter({
@@ -100,5 +101,7 @@ function quantiles(arguments) {
     }
   }
 
+  const endTime = Date.now();
+  executionTimes.push({ fun: "quantiles.js", params: {}, success: true, time: endTime - startTime });
   return quantiles;
 }

--- a/src/pg_to_evalscript/javascript_processes/rearrange.js
+++ b/src/pg_to_evalscript/javascript_processes/rearrange.js
@@ -1,4 +1,5 @@
 function rearrange(arguments) {
+  const startTime = Date.now();
   const { data, order } = arguments;
 
   validateParameter({
@@ -39,5 +40,7 @@ function rearrange(arguments) {
     newData.push(data[el]);
   }
 
+  const endTime = Date.now();
+  executionTimes.push({ fun: "rearrange.js", params: {}, success: true, time: endTime - startTime });
   return newData;
 }

--- a/src/pg_to_evalscript/javascript_processes/reduce_dimension.js
+++ b/src/pg_to_evalscript/javascript_processes/reduce_dimension.js
@@ -1,4 +1,5 @@
 function reduce_dimension(arguments) {
+  const startTime = Date.now();
   const { data, dimension, reducer, context = null } = arguments;
 
   validateParameter({
@@ -28,5 +29,7 @@ function reduce_dimension(arguments) {
 
   const newData = data.clone();
   newData.reduceByDimension(reducer, dimension, context);
+  const endTime = Date.now();
+  executionTimes.push({ fun: "reduce_dimension.js", params: {}, success: true, time: endTime - startTime });
   return newData;
 }

--- a/src/pg_to_evalscript/javascript_processes/rename_labels.js
+++ b/src/pg_to_evalscript/javascript_processes/rename_labels.js
@@ -1,4 +1,5 @@
 function rename_labels(arguments) {
+  const startTime = Date.now();
   const { data, dimension, target, source = [] } = arguments;
 
   if (data === undefined) {
@@ -67,5 +68,7 @@ function rename_labels(arguments) {
 
     data.getDimensionByName(dimension).labels[ind] = target[i];
   }
+  const endTime = Date.now();
+  executionTimes.push({ fun: "rename_labels.js", params: {}, success: true, time: endTime - startTime });
   return data;
 }

--- a/src/pg_to_evalscript/javascript_processes/resample_cube_temporal.js
+++ b/src/pg_to_evalscript/javascript_processes/resample_cube_temporal.js
@@ -1,4 +1,5 @@
 function resample_cube_temporal(arguments) {
+  const startTime = Date.now();
   const { data, target, dimension = null, valid_within = null } = arguments;
 
   validateParameter({
@@ -198,5 +199,7 @@ function resample_cube_temporal(arguments) {
     dataClone = resampledData.clone();
   }
 
+  const endTime = Date.now();
+  executionTimes.push({ fun: "resample_cube_temporal.js", params: {}, success: true, time: endTime - startTime });
   return resampledData;
 }

--- a/src/pg_to_evalscript/javascript_processes/round.js
+++ b/src/pg_to_evalscript/javascript_processes/round.js
@@ -1,4 +1,5 @@
 function round(arguments) {
+  const startTime = Date.now();
   const { x, p = 0 } = arguments;
 
   validateParameter({
@@ -30,5 +31,7 @@ function round(arguments) {
   const e = 1e-8; // Allow for rounding errors in f
   const r =
     f > 0.5 - e && f < 0.5 + e ? (i % 2 == 0 ? i : i + 1) : Math.round(n);
+  const endTime = Date.now();
+  executionTimes.push({ fun: "round.js", params: {}, success: true, time: endTime - startTime });
   return p ? r / m : r;
 }

--- a/src/pg_to_evalscript/javascript_processes/sd.js
+++ b/src/pg_to_evalscript/javascript_processes/sd.js
@@ -1,4 +1,5 @@
 function sd(arguments) {
+  const startTime = Date.now();
   const { data, ignore_nodata = true } = arguments;
 
   validateParameter({
@@ -30,6 +31,8 @@ function sd(arguments) {
 
     if (x === null) {
       if (!ignore_nodata) {
+        const endTime = Date.now();
+        executionTimes.push({ fun: "sd.js", params: {}, success: true, time: endTime - startTime });
         return null;
       } else {
         continue;
@@ -41,10 +44,14 @@ function sd(arguments) {
   }
 
   if (count === 0) {
+    const endTime = Date.now();
+    executionTimes.push({ fun: "sd.js", params: {}, success: true, time: endTime - startTime });
     return null;
   }
 
   if (count === 1) {
+    const endTime = Date.now();
+    executionTimes.push({ fun: "sd.js", params: {}, success: true, time: endTime - startTime });
     return 0;
   }
 
@@ -58,5 +65,7 @@ function sd(arguments) {
     sumOfSquares += Math.pow(x - mean, 2);
   }
 
+  const endTime = Date.now();
+  executionTimes.push({ fun: "sd.js", params: {}, success: true, time: endTime - startTime });
   return Math.sqrt(sumOfSquares / (count - 1));
 }

--- a/src/pg_to_evalscript/javascript_processes/sort.js
+++ b/src/pg_to_evalscript/javascript_processes/sort.js
@@ -1,4 +1,5 @@
 function sort(arguments) {
+  const startTime = Date.now();
   const { data, asc = true, nodata = null } = arguments;
 
   validateParameter({
@@ -57,6 +58,8 @@ function sort(arguments) {
     newData = [...arr_of_nulls, ...newData];
   }
 
+  const endTime = Date.now();
+  executionTimes.push({ fun: "sort.js", params: {}, success: true, time: endTime - startTime });
   return newData;
 }
 

--- a/src/pg_to_evalscript/javascript_processes/sum.js
+++ b/src/pg_to_evalscript/javascript_processes/sum.js
@@ -1,4 +1,5 @@
 function sum(arguments) {
+  const startTime = Date.now();
   const { data, ignore_nodata = true } = arguments;
 
   validateParameter({
@@ -43,5 +44,7 @@ function sum(arguments) {
     }
   }
 
+  const endTime = Date.now();
+  executionTimes.push({ fun: "sum.js", params: {}, success: true, time: endTime - startTime });
   return sum;
 }

--- a/src/pg_to_evalscript/javascript_processes/variance.js
+++ b/src/pg_to_evalscript/javascript_processes/variance.js
@@ -1,4 +1,5 @@
 function variance(arguments) {
+  const startTime = Date.now();
   const { data, ignore_nodata = true } = arguments;
 
   validateParameter({
@@ -41,10 +42,14 @@ function variance(arguments) {
   }
 
   if (count === 0) {
+    const endTime = Date.now();
+    executionTimes.push({ fun: "variance.js", params: {}, success: true, time: endTime - startTime });
     return null;
   }
 
   if (count === 1) {
+    const endTime = Date.now();
+    executionTimes.push({ fun: "variance.js", params: {}, success: true, time: endTime - startTime });
     return 0;
   }
 
@@ -58,5 +63,7 @@ function variance(arguments) {
     sumOfSquares += Math.pow(x - mean, 2);
   }
 
+  const endTime = Date.now();
+  executionTimes.push({ fun: "variance.js", params: {}, success: true, time: endTime - startTime });
   return sumOfSquares / (count - 1);
 }

--- a/src/pg_to_evalscript/node.py
+++ b/src/pg_to_evalscript/node.py
@@ -143,7 +143,12 @@ class Node:
 
     def write_call(self):
         return self.indent_by_level(
-            f"let {self.node_varname_prefix}{self.node_id} = {self.process_function_name}({self.arguments})"
+            f"""
+const startTime{self.process_function_name} = Date.now();
+let {self.node_varname_prefix}{self.node_id} = {self.process_function_name}({self.arguments})
+const endTime{self.process_function_name} = Date.now();
+executionTimes.push({{ fun: \"{self.process_function_name}\", params: {{}}, success: true, time: endTime{self.process_function_name} - startTime{self.process_function_name} }});
+            """
         )
 
     def write_function(self):


### PR DESCRIPTION
This is just for the purpose of exploring what takes the most time in the evalscript that is generated from process graph as part of https://github.com/Open-EO/openeo-sentinelhub-python-driver/issues/27.

The most time-consuming tasks are 
- `ndarray` function
    - consequently `DataCube` constructor
- `filter_temporal` process (`filter_temporal.js`)
- `reduce_dimension` process (`reduce_dimension.js`)
- `aggregate_temporal` (aggregate_temporal.js)
- others from `src/pg_to_evalscript/node.py`

These consume upwards of 10ms (=> should be multiplied by the number of pixels in the requested area to get approximate time these consume for the whole returned image)